### PR TITLE
Add suggested custom CSS for mkdocstrings indentation

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -56,3 +56,32 @@ img.copyright-logo {
         background-color: #212121;
     }
 }
+
+/* Customization for mkdocstrings */
+/* Indentation. */
+div.doc-contents:not(.first) {
+    padding-left: 25px;
+    border-left: .2rem solid var(--md-typeset-table-color);
+}
+
+/* Mark external links as such. */
+a.autorefs-external::after {
+    /* https://primer.style/octicons/arrow-up-right-24 */
+    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="rgb(0, 0, 0)" d="M18.25 15.5a.75.75 0 00.75-.75v-9a.75.75 0 00-.75-.75h-9a.75.75 0 000 1.5h7.19L6.22 16.72a.75.75 0 101.06 1.06L17.5 7.56v7.19c0 .414.336.75.75.75z"></path></svg>');
+    content: ' ';
+
+    display: inline-block;
+    position: relative;
+    top: 0.1em;
+    margin-left: 0.2em;
+    margin-right: 0.1em;
+
+    height: 1em;
+    width: 1em;
+    border-radius: 100%;
+    background-color: var(--md-typeset-a-color);
+}
+
+a.autorefs-external:hover::after {
+    background-color: var(--md-accent-fg-color);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,7 +87,6 @@ plugins:
           paths: ["."]
           options:
             show_root_heading: true
-            show_category_heading: true
 watch:
   - "README.md"
 


### PR DESCRIPTION
Makes it so that code hierarchy is properly displayed in the `mkdocstrings` generated code reference. Also disabled the `show_category_heading` option to reduce the crazy amount of nested headings.

![indentation](https://user-images.githubusercontent.com/9288571/193654128-4534e532-47e4-4697-a3b6-4d6bf6de3f09.png)
