### PR TITLE
Closes: #699 - Remove stale reference to `platform_slug_map`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,17 @@ jobs:
         uses: "networktocode/gh-action-setup-poetry-environment@v4"
       - name: "Linting: flake8"
         run: "poetry run invoke flake8"
+  check-docs-build:
+    runs-on: "ubuntu-22.04"
+    env:
+      INVOKE_NAUTOBOT_GOLDEN_CONFIG_LOCAL: "True"
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v4"
+      - name: "Setup environment"
+        uses: "networktocode/gh-action-setup-poetry-environment@v4"
+      - name: "Check Docs Build"
+        run: "poetry run invoke build-and-check-docs"
   poetry:
     runs-on: "ubuntu-22.04"
     env:
@@ -238,6 +249,10 @@ jobs:
         run: "echo RELEASE_VERSION=${GITHUB_REF:10} >> $GITHUB_ENV"
       - name: "Run Poetry Version"
         run: "poetry version $RELEASE_VERSION"
+      - name: "Install Dependencies (needed for mkdocs)"
+        run: "poetry install --no-root"
+      - name: "Build Documentation"
+        run: "poetry run invoke build-and-check-docs"
       - name: "Run Poetry Build"
         run: "poetry build"
       - name: "Upload binaries to release"
@@ -267,6 +282,10 @@ jobs:
         run: "echo RELEASE_VERSION=${GITHUB_REF:10} >> $GITHUB_ENV"
       - name: "Run Poetry Version"
         run: "poetry version $RELEASE_VERSION"
+      - name: "Install Dependencies (needed for mkdocs)"
+        run: "poetry install --no-root"
+      - name: "Build Documentation"
+        run: "poetry run invoke build-and-check-docs"
       - name: "Run Poetry Build"
         run: "poetry build"
       - name: "Push to PyPI"

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ This App is installed in the Nautobot Community Sandbox found over at [demo.naut
 Full web-based HTML documentation for this app can be found over on the [Nautobot Docs](https://docs.nautobot.com/projects/golden-config/en/latest/) website:
 
 - [User Guide](https://docs.nautobot.com/projects/golden-config/en/latest/user/app_overview/) - Overview, Using the App, Getting Started, Navigating compliance (cli, json, custom), backup, app usage, intended state creation.
-- [Administrator Guide](https://docs.nautobot.com/projects/golden-config/en/latest/admin/admin_install/) - How to Install, Configure, Upgrade, or Uninstall the App.
-- [Developer Guide](https://docs.nautobot.com/projects/golden-config/en/latest/dev/dev_contributing/) - Extending the App, Code Reference, Contribution Guide.
+- [Administrator Guide](https://docs.nautobot.com/projects/golden-config/en/latest/admin/install/) - How to Install, Configure, Upgrade, or Uninstall the App.
+- [Developer Guide](https://docs.nautobot.com/projects/golden-config/en/latest/dev/contributing/) - Extending the App, Code Reference, Contribution Guide.
 - [Release Notes / Changelog](https://docs.nautobot.com/projects/golden-config/en/latest/admin/release_notes/)
-- [Frequently Asked Questions](https://docs.nautobot.com/projects/golden-config/en/latest/user/app_faq/)
+- [Frequently Asked Questions](https://docs.nautobot.com/projects/golden-config/en/latest/user/faq/)
 
 ### Contributing to the Docs
 

--- a/docs/admin/install.md
+++ b/docs/admin/install.md
@@ -109,12 +109,14 @@ The app behavior can be controlled with the following list of settings:
 | default_deploy_status     | "Not Approved"                | "Not Approved" | A string that will be the name of the status you want as the default when create new config plans, you MUST create the status yourself before starting the app.     |
 | postprocessing_callables  | ['mypackage.myfunction']      | []      | A list of function paths, in dotted format, that are appended to the available methods for post-processing the intended configuration, for instance, the `render_secrets`. |
 | postprocessing_subscribed | ['mypackage.myfunction']      | []      | A list of function paths, that should exist as postprocessing_callables, that defines the order of application of during the post-processing process.                      |
-| platform_slug_map         | {"cisco_wlc": "cisco_aireos"} | None    | A dictionary in which the key is the platform slug and the value is what netutils uses in any "network_os" parameter within `netutils.config.compliance.parser_map`.       |
 | sot_agg_transposer        | "mypkg.transposer"            | None    | A string representation of a function that can post-process the graphQL data.                                                                                              |
 | per_feature_bar_width     | 0.15                          | 0.15    | The width of the table bar within the overview report                                                                                                                      |
 | per_feature_width         | 13                            | 13      | The width in inches that the overview table can be.                                                                                                                        |
 | per_feature_height        | 4                             | 4       | The height in inches that the overview table can be.                                                                                                                       |
 | jinja_env | {"lstrip_blocks": False} | See Note Below | A dictionary of Jinja2 Environment options compatible with Jinja2.SandboxEnvironment() |
+
+!!! note
+    `platform_slug_map` configuration was removed as of the `v2.0.0` release of Golden Config, for more information please review the [v2 Migration Guide](./migrating_to_v2.md)
 
 !!! note
     Over time the compliance report will become more dynamic, but for now allow users to configure the `per_*` configs in a way that fits best for them.

--- a/docs/admin/install.md
+++ b/docs/admin/install.md
@@ -122,9 +122,6 @@ The app behavior can be controlled with the following list of settings:
     Over time the compliance report will become more dynamic, but for now allow users to configure the `per_*` configs in a way that fits best for them.
 
 !!! note
-    Review [`nautobot_plugin_nornir`](https://docs.nautobot.com/projects/plugin-nornir/en/latest/user/app_feature_dispatcher/) for Nornir and dispatcher configuration options.
-
-!!! note
     Defaults for Jinja2 environment settings (`jinja_env`) are as follows:
 
     ```python

--- a/docs/admin/migrating_to_v2.md
+++ b/docs/admin/migrating_to_v2.md
@@ -43,7 +43,7 @@ If previously you have leveraged the `dispatcher_mapping` to use your preferred 
 !!! tip
     You can safely skip this section if your Dynamic Groups was not using slugs/Site/Region/DeviceRole or your Dynamic Groups are currently in the required state.
 
-In an effort to guide you along, you are highly encouraged to leverage the `nautobot-server audit_dynamic_groups` as [documented](https://docs.nautobot.com/projects/core/en/v2.0.0/user-guide/administration/tools/nautobot-server/#audit_dynamic_groups). You will know you have completed this step, when the scope of devices in your Dynamic Group match your expectations.
+In an effort to guide you along, you are highly encouraged to leverage the `nautobot-server audit_dynamic_groups` as [documented](https://docs.nautobot.com/projects/core/en/stable/user-guide/administration/tools/nautobot-server/#audit_dynamic_groups). You will know you have completed this step, when the scope of devices in your Dynamic Group match your expectations.
 
 ## GraphQL
 

--- a/nautobot_golden_config/utilities/config_postprocessing.py
+++ b/nautobot_golden_config/utilities/config_postprocessing.py
@@ -78,7 +78,7 @@ def render_secrets(config_postprocessing: str, configs: models.GoldenConfig, req
     if not config_postprocessing:
         return ""
 
-    # Based on https://docs.nautobot.com/projects/golden-config/en/latest/dev/dev_adr/#renders-secrets
+    # Based on https://docs.nautobot.com/projects/golden-config/en/latest/user/app_feature_config_postprocessing/?h=secrets#render-secrets
     # the Jinja2 environment that starts with Nautobot should not be used.
     jinja_env = SandboxedEnvironment(autoescape=True)
 


### PR DESCRIPTION
Verified on merge to develop this will update the `latest` tag of the docs, the `stable` tag will be updated on the next release. The tags `v2.0.0` & `v2.0.1` will have the incorrect reference since they are pointing to the tag in GitHub.