### PR TITLE
Close threaded db connections during config deployment

### DIFF
--- a/nautobot_golden_config/nornir_plays/config_deployment.py
+++ b/nautobot_golden_config/nornir_plays/config_deployment.py
@@ -1,4 +1,5 @@
 """Nornir job for deploying configurations."""
+
 from datetime import datetime
 import logging
 
@@ -21,13 +22,13 @@ from nautobot_plugin_nornir.plugins.inventory.nautobot_orm import NautobotORMInv
 from nautobot_golden_config.nornir_plays.processor import ProcessGoldenConfig
 from nautobot_golden_config.utilities.helper import dispatch_params
 from nautobot_golden_config.utilities.logger import NornirLogger
-
-
+from nautobot_golden_config.utilities.db_management import close_threaded_db_connections
 from nautobot_golden_config.utilities.constant import DEFAULT_DEPLOY_STATUS
 
 InventoryPluginRegister.register("nautobot-inventory", NautobotORMInventory)
 
 
+@close_threaded_db_connections
 def run_deployment(task: Task, logger: logging.Logger, config_plan_qs, deploy_job_result) -> Result:
     """Deploy configurations to device."""
     obj = task.host.data["obj"]


### PR DESCRIPTION
Added the close_threaded_db_connections decorator to run_deployment to ensure DB connections are closed when threaded tasks are completed.

Closes #713 