### PR TITLE
Fix Compliance Not Running

### DIFF
--- a/changes/749.fixed
+++ b/changes/749.fixed
@@ -1,0 +1,1 @@
+Corrected issue where consecutive Golden Config Jobs in All Golden Configs Job wouldn't execute if prior Job had an Exception raised.

--- a/docs/admin/troubleshooting/E3027.md
+++ b/docs/admin/troubleshooting/E3027.md
@@ -1,0 +1,17 @@
+# E3027 Details
+
+## Message emitted:
+
+`E3027: NornirNautobotException raised during backup tasks. Original exception message`
+
+## Description:
+
+A NornirNautobotException is raised during a Backup Job.
+
+## Troubleshooting:
+
+Review the exception message and worker logs to determine the cause of the failure.
+
+## Recommendation:
+
+This type of error is usually resource related or caused by a misconfiguration and should be logged as such.

--- a/docs/admin/troubleshooting/E3028.md
+++ b/docs/admin/troubleshooting/E3028.md
@@ -1,0 +1,17 @@
+# E3028 Details
+
+## Message emitted:
+
+`E3028: NornirNautobotException raised during compliance tasks. Original exception message`
+
+## Description:
+
+A NornirNautobotException is raised during a Compliance Job.
+
+## Troubleshooting:
+
+Review the exception message and worker logs to determine the cause of the failure.
+
+## Recommendation:
+
+This type of error is usually resource related or caused by a misconfiguration and should be logged as such.

--- a/docs/admin/troubleshooting/E3029.md
+++ b/docs/admin/troubleshooting/E3029.md
@@ -1,0 +1,17 @@
+# E3029 Details
+
+## Message emitted:
+
+`E3029: NornirNautobotException raised during intended tasks. Original exception message`
+
+## Description:
+
+A NornirNautobotException is raised during an Intended Job.
+
+## Troubleshooting:
+
+Review the exception message and worker logs to determine the cause of the failure.
+
+## Recommendation:
+
+This type of error is usually resource related or caused by a misconfiguration and should be logged as such.

--- a/docs/admin/troubleshooting/E3030.md
+++ b/docs/admin/troubleshooting/E3030.md
@@ -1,0 +1,17 @@
+# E3030 Details
+
+## Message emitted:
+
+`E3030: Failure during (Backup, Intended, Compliance) Job(s).`
+
+## Description:
+
+A NornirNautobotException is raised during a Backup, Intended, or Compliance Job.
+
+## Troubleshooting:
+
+Review the exception message and worker logs to determine the cause of the failure.
+
+## Recommendation:
+
+This type of error is usually resource related or caused by a misconfiguration and should be logged as such.

--- a/nautobot_golden_config/exceptions.py
+++ b/nautobot_golden_config/exceptions.py
@@ -11,3 +11,15 @@ class MissingReference(GoldenConfigError):
 
 class RenderConfigToPushError(GoldenConfigError):
     """Exception related to Render Configuration Postprocessing operations."""
+
+
+class BackupFailure(GoldenConfigError):
+    """Custom error for when there's a failure in Backup Job."""
+
+
+class IntendedGenerationFailure(GoldenConfigError):
+    """Custom error for when there's a failure in Intended Job."""
+
+
+class ComplianceFailure(GoldenConfigError):
+    """Custom error for when there's a failure in Compliance Job."""

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -317,7 +317,7 @@ class AllGoldenConfig(GoldenConfigJobMixin):
         failure_msg = f"`E3030:` Failure during {failed_jobs} Job(s)."
         if len(failed_jobs) > 0:
             self.logger.error(failure_msg)
-        if data["fail_job_on_task_failure"]:
+        if (len(failed_jobs) > 0 or error_msg) and data["fail_job_on_task_failure"]:
             if not error_msg:
                 error_msg = failure_msg
             # Raise error only if the job kwarg (checkbox) is selected to do so on the job execution form.
@@ -393,7 +393,7 @@ class AllDevicesGoldenConfig(GoldenConfigJobMixin, FormEntry):
         failure_msg = f"`E3030:` Failure during {failed_jobs} Job(s)."
         if len(failed_jobs) > 0:
             self.logger.error(failure_msg)
-        if data["fail_job_on_task_failure"]:
+        if (len(failed_jobs) > 0 or error_msg) and data["fail_job_on_task_failure"]:
             if not error_msg:
                 error_msg = failure_msg
             # Raise error only if the job kwarg (checkbox) is selected to do so on the job execution form.

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -274,7 +274,7 @@ class AllGoldenConfig(GoldenConfigJobMixin):
         )
         current_repos = get_refreshed_repos(job_obj=self, repo_types=gitrepo_types, data=self.qs)
         failed_jobs = []
-        error_msg = ""
+        error_msg, jobs_list = "", "All"
         for enabled, play in [
             (constant.ENABLE_INTENDED, config_intended),
             (constant.ENABLE_BACKUP, config_backup),
@@ -309,12 +309,10 @@ class AllGoldenConfig(GoldenConfigJobMixin):
                     repo["repo_obj"].commit_with_added(f"{self.Meta.name.upper()} JOB {now}")
                     repo["repo_obj"].push()
         if len(failed_jobs) > 1:
-            failed_jobs = ", ".join(failed_jobs)
+            jobs_list = ", ".join(failed_jobs)
         elif len(failed_jobs) == 1:
-            failed_jobs = failed_jobs[0]
-        elif len(failed_jobs) == 0:
-            failed_jobs = "All"
-        failure_msg = f"`E3030:` Failure during {failed_jobs} Job(s)."
+            jobs_list = failed_jobs[0]
+        failure_msg = f"`E3030:` Failure during {jobs_list} Job(s)."
         if len(failed_jobs) > 0:
             self.logger.error(failure_msg)
         if (len(failed_jobs) > 0 or error_msg) and data["fail_job_on_task_failure"]:
@@ -350,7 +348,7 @@ class AllDevicesGoldenConfig(GoldenConfigJobMixin, FormEntry):
         )
         current_repos = get_refreshed_repos(job_obj=self, repo_types=gitrepo_types, data=self.qs)
         failed_jobs = []
-        error_msg = ""
+        error_msg, jobs_list = "", "All"
         for enabled, play in [
             (constant.ENABLE_INTENDED, config_intended),
             (constant.ENABLE_BACKUP, config_backup),
@@ -385,12 +383,10 @@ class AllDevicesGoldenConfig(GoldenConfigJobMixin, FormEntry):
                     repo["repo_obj"].commit_with_added(f"{self.Meta.name.upper()} JOB {now}")
                     repo["repo_obj"].push()
         if len(failed_jobs) > 1:
-            failed_jobs = ", ".join(failed_jobs)
+            jobs_list = ", ".join(failed_jobs)
         elif len(failed_jobs) == 1:
-            failed_jobs = failed_jobs[0]
-        elif len(failed_jobs) == 0:
-            failed_jobs = "All"
-        failure_msg = f"`E3030:` Failure during {failed_jobs} Job(s)."
+            jobs_list = failed_jobs[0]
+        failure_msg = f"`E3030:` Failure during {jobs_list} Job(s)."
         if len(failed_jobs) > 0:
             self.logger.error(failure_msg)
         if (len(failed_jobs) > 0 or error_msg) and data["fail_job_on_task_failure"]:

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -307,9 +307,12 @@ class AllGoldenConfig(GoldenConfigJobMixin):
                     )
                     repo["repo_obj"].commit_with_added(f"{self.Meta.name.upper()} JOB {now}")
                     repo["repo_obj"].push()
+        failure_msg = f"Failure during {', '.join(failed_jobs) if len(failed_jobs) > 1 else failed_jobs[0]} Job."
         if len(failed_jobs) > 0:
-            self.logger.error(f"Failure during {', '.join(failed_jobs) if len(failed_jobs) > 1 else failed_jobs} Job.")
+            self.logger.error(failure_msg)
         if data["fail_job_on_task_failure"]:
+            if not error_msg:
+                error_msg = failure_msg
             # Raise error only if the job kwarg (checkbox) is selected to do so on the job execution form.
             raise NornirNautobotException(error_msg)
 
@@ -373,11 +376,12 @@ class AllDevicesGoldenConfig(GoldenConfigJobMixin, FormEntry):
                     )
                     repo["repo_obj"].commit_with_added(f"{self.Meta.name.upper()} JOB {now}")
                     repo["repo_obj"].push()
+        failure_msg = f"Failure during {', '.join(failed_jobs) if len(failed_jobs) > 1 else failed_jobs[0]} Job."
         if len(failed_jobs) > 0:
-            self.logger.error(
-                f"Failure during {', '.join(failed_jobs) if len(failed_jobs) > 1 else failed_jobs[0]} Job."
-            )
+            self.logger.error(failure_msg)
         if data["fail_job_on_task_failure"]:
+            if not error_msg:
+                error_msg = failure_msg
             # Raise error only if the job kwarg (checkbox) is selected to do so on the job execution form.
             raise NornirNautobotException(error_msg)
 

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -104,15 +104,15 @@ def gc_repos(func):
 
     def gc_repo_wrapper(self, *args, **kwargs):
         """Decorator used for handle repo syncing, commiting, and pushing."""
-        self.logger.debug("Compiling device data for GC job.", extra={"grouping": "Get Job Filter"})
+        self.job.logger.debug("Compiling device data for GC job.", extra={"grouping": "Get Job Filter"})
         self.qs = get_job_filter(kwargs)
-        self.logger.debug(
+        self.job.logger.debug(
             f"In scope device count for this job: {self.qs.count()}", extra={"grouping": "Get Job Filter"}
         )
-        self.logger.debug("Mapping device(s) to GC Settings.", extra={"grouping": "Device to Settings Map"})
+        self.job.logger.debug("Mapping device(s) to GC Settings.", extra={"grouping": "Device to Settings Map"})
         self.device_to_settings_map = get_device_to_settings_map(queryset=self.qs)
         gitrepo_types = list(set(get_repo_types_for_job(self.name)))
-        self.logger.debug(
+        self.job.logger.debug(
             f"Repository types to sync: {', '.join(sorted(gitrepo_types))}",
             extra={"grouping": "GC Repo Syncs"},
         )
@@ -127,14 +127,14 @@ def gc_repos(func):
                 raise NornirNautobotException(error_msg) from error
         finally:
             now = make_aware(datetime.now())
-            self.logger.debug(
+            self.job.logger.debug(
                 f"Finished the {self.Meta.name} job execution.",
                 extra={"grouping": "GC After Run"},
             )
             if current_repos:
                 for _, repo in current_repos.items():
                     if repo["to_commit"]:
-                        self.logger.debug(
+                        self.job.logger.debug(
                             f"Pushing {self.Meta.name} results to repo {repo['repo_obj'].base_url}.",
                             extra={"grouping": "GC Repo Commit and Push"},
                         )

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -528,6 +528,7 @@ class DeployConfigPlans(Job):
     def run(self, **data):  # pylint: disable=arguments-differ
         """Run config plan deployment process."""
         self.logger.debug("Starting config plan deployment job.")
+        self.data = data
         config_deployment(self)
 
 
@@ -543,7 +544,7 @@ class DeployConfigPlanJobButtonReceiver(JobButtonReceiver):
     def receive_job_button(self, obj):
         """Run config plan deployment process."""
         self.logger.debug("Starting config plan deployment job.")
-        data = {"debug": False, "config_plan": ConfigPlan.objects.filter(id=obj.id)}
+        self.data = {"debug": False, "config_plan": ConfigPlan.objects.filter(id=obj.id)}
         config_deployment(self)
 
 

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -274,6 +274,7 @@ class AllGoldenConfig(GoldenConfigJobMixin):
         )
         current_repos = get_refreshed_repos(job_obj=self, repo_types=gitrepo_types, data=self.qs)
         failed_jobs = []
+        error_msg = ""
         for enabled, play in [
             (constant.ENABLE_INTENDED, config_intended),
             (constant.ENABLE_BACKUP, config_backup),
@@ -349,6 +350,7 @@ class AllDevicesGoldenConfig(GoldenConfigJobMixin, FormEntry):
         )
         current_repos = get_refreshed_repos(job_obj=self, repo_types=gitrepo_types, data=self.qs)
         failed_jobs = []
+        error_msg = ""
         for enabled, play in [
             (constant.ENABLE_INTENDED, config_intended),
             (constant.ENABLE_BACKUP, config_backup),

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -307,7 +307,13 @@ class AllGoldenConfig(GoldenConfigJobMixin):
                     )
                     repo["repo_obj"].commit_with_added(f"{self.Meta.name.upper()} JOB {now}")
                     repo["repo_obj"].push()
-        failure_msg = f"Failure during {', '.join(failed_jobs) if len(failed_jobs) > 1 else failed_jobs[0]} Job."
+        if len(failed_jobs) > 1:
+            failed_jobs = ", ".join(failed_jobs)
+        elif len(failed_jobs) == 1:
+            failed_jobs = failed_jobs[0]
+        elif len(failed_jobs) == 0:
+            failed_jobs = "All"
+        failure_msg = f"Failure during {failed_jobs} Job."
         if len(failed_jobs) > 0:
             self.logger.error(failure_msg)
         if data["fail_job_on_task_failure"]:
@@ -376,7 +382,13 @@ class AllDevicesGoldenConfig(GoldenConfigJobMixin, FormEntry):
                     )
                     repo["repo_obj"].commit_with_added(f"{self.Meta.name.upper()} JOB {now}")
                     repo["repo_obj"].push()
-        failure_msg = f"Failure during {', '.join(failed_jobs) if len(failed_jobs) > 1 else failed_jobs[0]} Job."
+        if len(failed_jobs) > 1:
+            failed_jobs = ", ".join(failed_jobs)
+        elif len(failed_jobs) == 1:
+            failed_jobs = failed_jobs[0]
+        elif len(failed_jobs) == 0:
+            failed_jobs = "All"
+        failure_msg = f"Failure during {failed_jobs} Job."
         if len(failed_jobs) > 0:
             self.logger.error(failure_msg)
         if data["fail_job_on_task_failure"]:

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -258,7 +258,7 @@ class AllGoldenConfig(GoldenConfigJobMixin):
         description = "Process to run all Golden Configuration jobs configured."
         has_sensitive_variables = False
 
-    def run(self, *args, **data):  # pylint: disable=unused-argument
+    def run(self, *args, **data):  # pylint: disable=unused-argument, too-many-branches
         """Run all jobs on a single device."""
         self.logger.debug("Compiling device data for GC job.", extra={"grouping": "Get Job Filter"})
         self.qs = get_job_filter(data)
@@ -334,7 +334,7 @@ class AllDevicesGoldenConfig(GoldenConfigJobMixin, FormEntry):
         description = "Process to run all Golden Configuration jobs configured against multiple devices."
         has_sensitive_variables = False
 
-    def run(self, *args, **data):  # pylint: disable=unused-argument
+    def run(self, *args, **data):  # pylint: disable=unused-argument, too-many-branches
         """Run all jobs on multiple devices."""
         self.logger.debug("Compiling device data for GC job.", extra={"grouping": "Get Job Filter"})
         self.qs = get_job_filter(data)

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -272,11 +272,10 @@ class AllGoldenConfig(GoldenConfigJobMixin):
         description = "Process to run all Golden Configuration jobs configured."
         has_sensitive_variables = False
 
-    @gc_repos
     def run(self, *args, **data):  # pylint: disable=unused-argument
         """Run all jobs on a single device."""
         if constant.ENABLE_INTENDED:
-            config_intended(
+            gc_repos(config_intended)(
                 self.job_result,
                 self.logger.getEffectiveLevel(),
                 self,
@@ -284,14 +283,14 @@ class AllGoldenConfig(GoldenConfigJobMixin):
                 self.device_to_settings_map,
             )
         if constant.ENABLE_BACKUP:
-            config_backup(
+            gc_repos(config_backup)(
                 self.job_result,
                 self.logger.getEffectiveLevel(),
                 self.qs,
                 self.device_to_settings_map,
             )
         if constant.ENABLE_COMPLIANCE:
-            config_compliance(
+            gc_repos(config_compliance)(
                 self.job_result,
                 self.logger.getEffectiveLevel(),
                 self.qs,

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -374,7 +374,9 @@ class AllDevicesGoldenConfig(GoldenConfigJobMixin, FormEntry):
                     repo["repo_obj"].commit_with_added(f"{self.Meta.name.upper()} JOB {now}")
                     repo["repo_obj"].push()
         if len(failed_jobs) > 0:
-            self.logger.error(f"Failure during {', '.join(failed_jobs) if len(failed_jobs) > 1 else failed_jobs} Job.")
+            self.logger.error(
+                f"Failure during {', '.join(failed_jobs) if len(failed_jobs) > 1 else failed_jobs[0]} Job."
+            )
         if data["fail_job_on_task_failure"]:
             # Raise error only if the job kwarg (checkbox) is selected to do so on the job execution form.
             raise NornirNautobotException(error_msg)

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -168,13 +168,14 @@ class FormEntry:  # pylint disable=too-few-public-method
         label="Device Status",
     )
     debug = BooleanVar(description="Enable for more verbose debug logging")
-    fail_job_on_task_failure = BooleanVar(
-        description="If any device in the tasks list fails, fail the entire job result."
-    )
 
 
 class GoldenConfigJobMixin(Job):  # pylint: disable=abstract-method
     """Reused mixin to be able to set defaults for instance attributes in all GC jobs."""
+
+    fail_job_on_task_failure = BooleanVar(
+        description="If any device in the tasks list fails, fail the entire job result."
+    )
 
     def __init__(self, *args, **kwargs):
         """Initialize the job."""

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -174,9 +174,7 @@ class FormEntry:  # pylint disable=too-few-public-method
 class GoldenConfigJobMixin(Job):  # pylint: disable=abstract-method
     """Reused mixin to be able to set defaults for instance attributes in all GC jobs."""
 
-    fail_job_on_task_failure = BooleanVar(
-        description="If any device in the tasks list fails, fail the entire job result."
-    )
+    fail_job_on_task_failure = BooleanVar(description="If any tasks for any device fails, fail the entire job result.")
 
     def __init__(self, *args, **kwargs):
         """Initialize the job."""

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -314,7 +314,7 @@ class AllGoldenConfig(GoldenConfigJobMixin):
             failed_jobs = failed_jobs[0]
         elif len(failed_jobs) == 0:
             failed_jobs = "All"
-        failure_msg = f"Failure during {failed_jobs} Job."
+        failure_msg = f"`E3030:` Failure during {failed_jobs} Job(s)."
         if len(failed_jobs) > 0:
             self.logger.error(failure_msg)
         if data["fail_job_on_task_failure"]:
@@ -390,7 +390,7 @@ class AllDevicesGoldenConfig(GoldenConfigJobMixin, FormEntry):
             failed_jobs = failed_jobs[0]
         elif len(failed_jobs) == 0:
             failed_jobs = "All"
-        failure_msg = f"Failure during {failed_jobs} Job."
+        failure_msg = f"`E3030:` Failure during {failed_jobs} Job(s)."
         if len(failed_jobs) > 0:
             self.logger.error(failure_msg)
         if data["fail_job_on_task_failure"]:

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -202,13 +202,7 @@ class ComplianceJob(GoldenConfigJobMixin, FormEntry):
         if not constant.ENABLE_COMPLIANCE:
             self.logger.critical("Compliance is disabled in application settings.")
             raise ValueError("Compliance is disabled in application settings.")
-        config_compliance(
-            self.job_result,
-            self.logger.getEffectiveLevel(),
-            self,
-            self.qs,  # pylint: disable=no-member
-            self.device_to_settings_map,  # pylint: disable=no-member
-        )
+        config_compliance(self)
 
 
 class IntendedJob(GoldenConfigJobMixin, FormEntry):
@@ -228,13 +222,7 @@ class IntendedJob(GoldenConfigJobMixin, FormEntry):
         if not constant.ENABLE_INTENDED:
             self.logger.critical("Intended Generation is disabled in application settings.")
             raise ValueError("Intended Generation is disabled in application settings.")
-        config_intended(
-            self.job_result,
-            self.logger.getEffectiveLevel(),
-            self,
-            self.qs,  # pylint: disable=no-member
-            self.device_to_settings_map,  # pylint: disable=no-member
-        )
+        config_intended(self)
 
 
 class BackupJob(GoldenConfigJobMixin, FormEntry):
@@ -254,12 +242,7 @@ class BackupJob(GoldenConfigJobMixin, FormEntry):
         if not constant.ENABLE_BACKUP:
             self.logger.critical("Backups are disabled in application settings.")
             raise ValueError("Backups are disabled in application settings.")
-        config_backup(
-            self.job_result,
-            self.logger.getEffectiveLevel(),
-            self.qs,
-            self.device_to_settings_map,
-        )
+        config_backup(self)
 
 
 class AllGoldenConfig(GoldenConfigJobMixin):
@@ -298,13 +281,7 @@ class AllGoldenConfig(GoldenConfigJobMixin):
         ]:
             try:
                 if enabled:
-                    play(
-                        self.job_result,
-                        self.logger.getEffectiveLevel(),
-                        self,
-                        self.qs,
-                        self.device_to_settings_map,
-                    )
+                    play(self)
             except BackupFailure:
                 self.logger.error("Backup failure occurred!")
                 failed_jobs.append("Backup")
@@ -370,13 +347,7 @@ class AllDevicesGoldenConfig(GoldenConfigJobMixin, FormEntry):
         ]:
             try:
                 if enabled:
-                    play(
-                        self.job_result,
-                        self.logger.getEffectiveLevel(),
-                        self,
-                        self.qs,
-                        self.device_to_settings_map,
-                    )
+                    play(self)
             except BackupFailure:
                 self.logger.error("Backup failure occurred!")
                 failed_jobs.append("Backup")
@@ -555,7 +526,7 @@ class DeployConfigPlans(Job):
     def run(self, **data):  # pylint: disable=arguments-differ
         """Run config plan deployment process."""
         self.logger.debug("Starting config plan deployment job.")
-        config_deployment(self.job_result, self.logger.getEffectiveLevel(), data)
+        config_deployment(self)
 
 
 class DeployConfigPlanJobButtonReceiver(JobButtonReceiver):
@@ -571,7 +542,7 @@ class DeployConfigPlanJobButtonReceiver(JobButtonReceiver):
         """Run config plan deployment process."""
         self.logger.debug("Starting config plan deployment job.")
         data = {"debug": False, "config_plan": ConfigPlan.objects.filter(id=obj.id)}
-        config_deployment(self.job_result, self.logger.getEffectiveLevel(), data)
+        config_deployment(self)
 
 
 class SyncGoldenConfigWithDynamicGroups(Job):

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -104,15 +104,15 @@ def gc_repos(func):
 
     def gc_repo_wrapper(self, *args, **kwargs):
         """Decorator used for handle repo syncing, commiting, and pushing."""
-        self.job.logger.debug("Compiling device data for GC job.", extra={"grouping": "Get Job Filter"})
+        self.logger.debug("Compiling device data for GC job.", extra={"grouping": "Get Job Filter"})
         self.qs = get_job_filter(kwargs)
-        self.job.logger.debug(
+        self.logger.debug(
             f"In scope device count for this job: {self.qs.count()}", extra={"grouping": "Get Job Filter"}
         )
-        self.job.logger.debug("Mapping device(s) to GC Settings.", extra={"grouping": "Device to Settings Map"})
+        self.logger.debug("Mapping device(s) to GC Settings.", extra={"grouping": "Device to Settings Map"})
         self.device_to_settings_map = get_device_to_settings_map(queryset=self.qs)
         gitrepo_types = list(set(get_repo_types_for_job(self.name)))
-        self.job.logger.debug(
+        self.logger.debug(
             f"Repository types to sync: {', '.join(sorted(gitrepo_types))}",
             extra={"grouping": "GC Repo Syncs"},
         )
@@ -127,14 +127,14 @@ def gc_repos(func):
                 raise NornirNautobotException(error_msg) from error
         finally:
             now = make_aware(datetime.now())
-            self.job.logger.debug(
+            self.logger.debug(
                 f"Finished the {self.Meta.name} job execution.",
                 extra={"grouping": "GC After Run"},
             )
             if current_repos:
                 for _, repo in current_repos.items():
                     if repo["to_commit"]:
-                        self.job.logger.debug(
+                        self.logger.debug(
                             f"Pushing {self.Meta.name} results to repo {repo['repo_obj'].base_url}.",
                             extra={"grouping": "GC Repo Commit and Push"},
                         )

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -123,7 +123,7 @@ def gc_repos(func):
         except Exception as error:  # pylint: disable=broad-exception-caught
             error_msg = f"`E3001:` General Exception handler, original error message ```{error}```"
             # Raise error only if the job kwarg (checkbox) is selected to do so on the job execution form.
-            if kwargs["fail_job_on_task_failure"]:
+            if kwargs.get("fail_job_on_task_failure"):
                 raise NornirNautobotException(error_msg) from error
         finally:
             now = make_aware(datetime.now())

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -272,10 +272,11 @@ class AllGoldenConfig(GoldenConfigJobMixin):
         description = "Process to run all Golden Configuration jobs configured."
         has_sensitive_variables = False
 
+    @gc_repos
     def run(self, *args, **data):  # pylint: disable=unused-argument
         """Run all jobs on a single device."""
         if constant.ENABLE_INTENDED:
-            gc_repos(config_intended)(
+            config_intended(
                 self.job_result,
                 self.logger.getEffectiveLevel(),
                 self,
@@ -283,14 +284,14 @@ class AllGoldenConfig(GoldenConfigJobMixin):
                 self.device_to_settings_map,
             )
         if constant.ENABLE_BACKUP:
-            gc_repos(config_backup)(
+            config_backup(
                 self.job_result,
                 self.logger.getEffectiveLevel(),
                 self.qs,
                 self.device_to_settings_map,
             )
         if constant.ENABLE_COMPLIANCE:
-            gc_repos(config_compliance)(
+            config_compliance(
                 self.job_result,
                 self.logger.getEffectiveLevel(),
                 self.qs,

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -529,6 +529,11 @@ class DeployConfigPlans(Job):
         description = "Deploy config plans to devices."
         has_sensitive_variables = False
 
+    def __init__(self, *args, **kwargs):
+        """Initialize the job."""
+        super().__init__(*args, **kwargs)
+        self.data = {}
+
     def run(self, **data):  # pylint: disable=arguments-differ
         """Run config plan deployment process."""
         self.logger.debug("Starting config plan deployment job.")
@@ -544,6 +549,11 @@ class DeployConfigPlanJobButtonReceiver(JobButtonReceiver):
 
         name = "Deploy Config Plan (Job Button Receiver)"
         has_sensitive_variables = False
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the job."""
+        super().__init__(*args, **kwargs)
+        self.data = {}
 
     def receive_job_button(self, obj):
         """Run config plan deployment process."""

--- a/nautobot_golden_config/nornir_plays/config_backup.py
+++ b/nautobot_golden_config/nornir_plays/config_backup.py
@@ -123,7 +123,7 @@ def config_backup(job):
             "options": {
                 "credentials_class": NORNIR_SETTINGS.get("credentials"),
                 "params": NORNIR_SETTINGS.get("inventory_params"),
-                "queryset": qs,
+                "queryset": job.qs,
                 "defaults": {"now": now},
             },
         },

--- a/nautobot_golden_config/nornir_plays/config_backup.py
+++ b/nautobot_golden_config/nornir_plays/config_backup.py
@@ -1,4 +1,5 @@
 """Nornir job for backing up actual config."""
+
 # pylint: disable=relative-beyond-top-level
 import logging
 import os
@@ -118,7 +119,7 @@ def config_backup(job_result, log_level, qs, device_to_settings_map):
         nr_with_processors = nornir_obj.with_processors([ProcessGoldenConfig(logger)])
 
         logger.debug("Run nornir backup tasks.")
-        nr_with_processors.run(
+        results = nr_with_processors.run(
             task=run_backup,
             name="BACKUP CONFIG",
             logger=logger,
@@ -128,3 +129,4 @@ def config_backup(job_result, log_level, qs, device_to_settings_map):
         )
         logger.debug("Completed configuration from devices.")
     logger.debug("Completed configuration backup job for devices.")
+    return results

--- a/nautobot_golden_config/nornir_plays/config_compliance.py
+++ b/nautobot_golden_config/nornir_plays/config_compliance.py
@@ -189,29 +189,37 @@ def config_compliance(job):  # pylint: disable=unused-argument
 
     for settings in set(job.device_to_settings_map.values()):
         verify_settings(logger, settings, ["backup_path_template", "intended_path_template"])
-    with InitNornir(
-        runner=NORNIR_SETTINGS.get("runner"),
-        logging={"enabled": False},
-        inventory={
-            "plugin": "nautobot-inventory",
-            "options": {
-                "credentials_class": NORNIR_SETTINGS.get("credentials"),
-                "params": NORNIR_SETTINGS.get("inventory_params"),
-                "queryset": job.qs,
-                "defaults": {"now": now},
+    try:
+        with InitNornir(
+            runner=NORNIR_SETTINGS.get("runner"),
+            logging={"enabled": False},
+            inventory={
+                "plugin": "nautobot-inventory",
+                "options": {
+                    "credentials_class": NORNIR_SETTINGS.get("credentials"),
+                    "params": NORNIR_SETTINGS.get("inventory_params"),
+                    "queryset": job.qs,
+                    "defaults": {"now": now},
+                },
             },
-        },
-    ) as nornir_obj:
-        nr_with_processors = nornir_obj.with_processors([ProcessGoldenConfig(logger)])
+        ) as nornir_obj:
+            nr_with_processors = nornir_obj.with_processors([ProcessGoldenConfig(logger)])
 
-        logger.debug("Run nornir compliance tasks.")
-        results = nr_with_processors.run(
-            task=run_compliance,
-            name="RENDER COMPLIANCE TASK GROUP",
-            logger=logger,
-            device_to_settings_map=job.device_to_settings_map,
-            rules=rules,
+            logger.debug("Run nornir compliance tasks.")
+            results = nr_with_processors.run(
+                task=run_compliance,
+                name="RENDER COMPLIANCE TASK GROUP",
+                logger=logger,
+                device_to_settings_map=job.device_to_settings_map,
+                rules=rules,
+            )
+    except NornirNautobotException as err:
+        logger.error(
+            f"`E3028:` NornirNautobotException raised during compliance tasks. Original exception message: ```{err}```"
         )
+        # re-raise Exception if it's raised from nornir-nautobot or nautobot-app-nornir
+        if str(err).startswith("`E2") or str(err).startswith("`E1"):
+            raise NornirNautobotException(err) from err
     logger.debug("Completed compliance job for devices.")
     if results.failed:
         raise ComplianceFailure()

--- a/nautobot_golden_config/nornir_plays/config_compliance.py
+++ b/nautobot_golden_config/nornir_plays/config_compliance.py
@@ -14,6 +14,7 @@ from netutils.config.compliance import _open_file_config, parser_map, section_co
 from nornir import InitNornir
 from nornir.core.plugins.inventory import InventoryPluginRegister
 from nornir.core.task import Result, Task
+from nornir_nautobot.exceptions import NornirNautobotException
 from nautobot_golden_config.choices import ComplianceRuleConfigTypeChoice
 from nautobot_golden_config.exceptions import ComplianceFailure
 from nautobot_golden_config.models import ComplianceRule, ConfigCompliance, GoldenConfig

--- a/nautobot_golden_config/nornir_plays/config_intended.py
+++ b/nautobot_golden_config/nornir_plays/config_intended.py
@@ -1,4 +1,5 @@
 """Nornir job for generating the intended config."""
+
 # pylint: disable=relative-beyond-top-level
 import logging
 import os
@@ -12,6 +13,7 @@ from nornir_nautobot.exceptions import NornirNautobotException
 from nornir_nautobot.plugins.tasks.dispatcher import dispatcher
 from nautobot_plugin_nornir.constants import NORNIR_SETTINGS
 from nautobot_plugin_nornir.plugins.inventory.nautobot_orm import NautobotORMInventory
+from nautobot_golden_config.exceptions import IntendedGenerationFailure
 from nautobot_golden_config.models import GoldenConfig
 from nautobot_golden_config.nornir_plays.processor import ProcessGoldenConfig
 from nautobot_golden_config.utilities.db_management import close_threaded_db_connections
@@ -127,7 +129,7 @@ def config_intended(job_result, log_level, job_class_instance, qs, device_to_set
 
         logger.debug("Run nornir render config tasks.")
         # Run the Nornir Tasks
-        nr_with_processors.run(
+        results = nr_with_processors.run(
             task=run_template,
             name="RENDER CONFIG",
             logger=logger,
@@ -135,3 +137,6 @@ def config_intended(job_result, log_level, job_class_instance, qs, device_to_set
             job_class_instance=job_class_instance,
             jinja_env=jinja_env,
         )
+
+    if results.failed:
+        raise IntendedGenerationFailure()

--- a/nautobot_golden_config/nornir_plays/config_intended.py
+++ b/nautobot_golden_config/nornir_plays/config_intended.py
@@ -135,7 +135,7 @@ def config_intended(job):
             name="RENDER CONFIG",
             logger=logger,
             device_to_settings_map=job.device_to_settings_map,
-            job_class_instance=job.job_class_instance,
+            job_class_instance=job,
             jinja_env=jinja_env,
         )
 

--- a/nautobot_golden_config/nornir_plays/config_intended.py
+++ b/nautobot_golden_config/nornir_plays/config_intended.py
@@ -141,7 +141,7 @@ def config_intended(job):
             )
     except NornirNautobotException as err:
         logger.error(
-            f"`E3029:` NornirNautobotException raised during backup tasks. Original exception message: ```{err}```"
+            f"`E3029:` NornirNautobotException raised during intended tasks. Original exception message: ```{err}```"
         )
         # re-raise Exception if it's raised from nornir-nautobot or nautobot-app-nornir
         if str(err).startswith("`E2") or str(err).startswith("`E1"):

--- a/nautobot_golden_config/nornir_plays/processor.py
+++ b/nautobot_golden_config/nornir_plays/processor.py
@@ -12,31 +12,31 @@ class ProcessGoldenConfig(BaseLoggingProcessor):
         """Set logging facility."""
         self.logger = logger
 
-    def task_completed(self, task: Task, result: AggregatedResult) -> None:
-        """Task outside of thread to determine what to do."""
-        if result.failed:
-            self.logger.error(f"{task.name} failed: {result}")
-            raise ValueError(result)
+    # def task_completed(self, task: Task, result: AggregatedResult) -> None:
+    #     """Task outside of thread to determine what to do."""
+    #     if result.failed:
+    #         self.logger.error(f"{task.name} failed: {result}")
+    #         raise ValueError(result)
 
-    def _find_result_exceptions(self, result):
-        """Walk the results and return only valid Exceptions.
+    # def _find_result_exceptions(self, result):
+    #     """Walk the results and return only valid Exceptions.
 
-        NornirNautobotException is expected to be raised in some situations.
-        """
-        valid_exceptions = []
-        if result.failed:
-            if isinstance(result, MultiResult) and hasattr(result, "exception"):
-                if not isinstance(result.exception, NornirNautobotException):
-                    # return exception and traceback output
-                    valid_exceptions.append([result.exception, result.result])
-            elif isinstance(result, Result) and hasattr(result, "exception"):
-                if not isinstance(result.exception, NornirNautobotException):
-                    # return exception and traceback output
-                    valid_exceptions.append([result.exception, result.result])
-            elif hasattr(result, "exception") and hasattr(result.exception, "result"):
-                for exception_result in result.exception.result:
-                    valid_exceptions += self._find_result_exceptions(exception_result)
-        return valid_exceptions
+    #     NornirNautobotException is expected to be raised in some situations.
+    #     """
+    #     valid_exceptions = []
+    #     if result.failed:
+    #         if isinstance(result, MultiResult) and hasattr(result, "exception"):
+    #             if not isinstance(result.exception, NornirNautobotException):
+    #                 # return exception and traceback output
+    #                 valid_exceptions.append([result.exception, result.result])
+    #         elif isinstance(result, Result) and hasattr(result, "exception"):
+    #             if not isinstance(result.exception, NornirNautobotException):
+    #                 # return exception and traceback output
+    #                 valid_exceptions.append([result.exception, result.result])
+    #         elif hasattr(result, "exception") and hasattr(result.exception, "result"):
+    #             for exception_result in result.exception.result:
+    #                 valid_exceptions += self._find_result_exceptions(exception_result)
+    #     return valid_exceptions
 
     def task_instance_completed(self, task: Task, host: Host, result: MultiResult) -> None:
         """Nornir processor task completion for golden configurations.

--- a/nautobot_golden_config/nornir_plays/processor.py
+++ b/nautobot_golden_config/nornir_plays/processor.py
@@ -12,6 +12,12 @@ class ProcessGoldenConfig(BaseLoggingProcessor):
         """Set logging facility."""
         self.logger = logger
 
+    def task_completed(self, task: Task, result: AggregatedResult) -> None:
+        """Task outside of thread to determine what to do."""
+        if result.failed:
+            self.logger.info("Failed task found!")
+            raise ValueError()
+
     def _find_result_exceptions(self, result):
         """Walk the results and return only valid Exceptions.
 

--- a/nautobot_golden_config/nornir_plays/processor.py
+++ b/nautobot_golden_config/nornir_plays/processor.py
@@ -12,31 +12,25 @@ class ProcessGoldenConfig(BaseLoggingProcessor):
         """Set logging facility."""
         self.logger = logger
 
-    # def task_completed(self, task: Task, result: AggregatedResult) -> None:
-    #     """Task outside of thread to determine what to do."""
-    #     if result.failed:
-    #         self.logger.error(f"{task.name} failed: {result}")
-    #         raise ValueError(result)
+    def _find_result_exceptions(self, result):
+        """Walk the results and return only valid Exceptions.
 
-    # def _find_result_exceptions(self, result):
-    #     """Walk the results and return only valid Exceptions.
-
-    #     NornirNautobotException is expected to be raised in some situations.
-    #     """
-    #     valid_exceptions = []
-    #     if result.failed:
-    #         if isinstance(result, MultiResult) and hasattr(result, "exception"):
-    #             if not isinstance(result.exception, NornirNautobotException):
-    #                 # return exception and traceback output
-    #                 valid_exceptions.append([result.exception, result.result])
-    #         elif isinstance(result, Result) and hasattr(result, "exception"):
-    #             if not isinstance(result.exception, NornirNautobotException):
-    #                 # return exception and traceback output
-    #                 valid_exceptions.append([result.exception, result.result])
-    #         elif hasattr(result, "exception") and hasattr(result.exception, "result"):
-    #             for exception_result in result.exception.result:
-    #                 valid_exceptions += self._find_result_exceptions(exception_result)
-    #     return valid_exceptions
+        NornirNautobotException is expected to be raised in some situations.
+        """
+        valid_exceptions = []
+        if result.failed:
+            if isinstance(result, MultiResult) and hasattr(result, "exception"):
+                if not isinstance(result.exception, NornirNautobotException):
+                    # return exception and traceback output
+                    valid_exceptions.append([result.exception, result.result])
+            elif isinstance(result, Result) and hasattr(result, "exception"):
+                if not isinstance(result.exception, NornirNautobotException):
+                    # return exception and traceback output
+                    valid_exceptions.append([result.exception, result.result])
+            elif hasattr(result, "exception") and hasattr(result.exception, "result"):
+                for exception_result in result.exception.result:
+                    valid_exceptions += self._find_result_exceptions(exception_result)
+        return valid_exceptions
 
     def task_instance_completed(self, task: Task, host: Host, result: MultiResult) -> None:
         """Nornir processor task completion for golden configurations.
@@ -50,13 +44,9 @@ class ProcessGoldenConfig(BaseLoggingProcessor):
             None
         """
         host.close_connections()
+        exceptions = self._find_result_exceptions(result)
 
-        # Complex logic to see if the task exception is expected, which is depicted by
-        # a sub task raising a NornirNautobotException.
-        if result.failed:
-            for level_1_result in result:
-                if hasattr(level_1_result, "exception") and hasattr(level_1_result.exception, "result"):
-                    for level_2_result in level_1_result.exception.result:
-                        if isinstance(level_2_result.exception, NornirNautobotException):
-                            return
-            self.logger.error(f"{task.name} failed: {result.exception}")
+        if result.failed and exceptions:
+            exception_string = ", ".join([str(e[0]) for e in exceptions])
+            # Log only exception summary to users
+            self.logger.error(f"{task.name} failed: {exception_string}", extra={"object": task.host.data["obj"]})

--- a/nautobot_golden_config/nornir_plays/processor.py
+++ b/nautobot_golden_config/nornir_plays/processor.py
@@ -1,6 +1,6 @@
 """Processor used by Golden Config to catch unknown errors."""
 from nornir.core.inventory import Host
-from nornir.core.task import AggregatedResult, MultiResult, Result, Task
+from nornir.core.task import MultiResult, Result, Task
 from nornir_nautobot.exceptions import NornirNautobotException
 from nornir_nautobot.plugins.processors import BaseLoggingProcessor
 
@@ -11,12 +11,6 @@ class ProcessGoldenConfig(BaseLoggingProcessor):
     def __init__(self, logger):
         """Set logging facility."""
         self.logger = logger
-
-    def task_completed(self, task: Task, result: AggregatedResult) -> None:
-        """Task outside of thread to determine what to do."""
-        if result.failed:
-            self.logger.info("Failed task found!")
-            raise ValueError()
 
     def _find_result_exceptions(self, result):
         """Walk the results and return only valid Exceptions.


### PR DESCRIPTION
This PR addresses the issue mentioned in #749. After some investigation it was found that any Exceptions being thrown during one of the Jobs will cause consecutive Golden Config tasks to never be ran. It was also found that Exceptions weren't being logged or bubbled up to be handled appropriately. This PR resolves all of those issues and attempts to log failures in a much more user friendly manner. It allows for generalized Exceptions to be raised and cause a Job to be failed like expected. It also includes a refactoring of the config_* functions to all work by just passing the Job itself so they have a standardized interface.