### PR TITLE
Closes #759 - Repo types not detected

### DIFF
--- a/changes/759.fixed
+++ b/changes/759.fixed
@@ -1,0 +1,1 @@
+Fixes Repositories not syncing in single jobs due to a change in the Job class API #5692

--- a/changes/759.fixed
+++ b/changes/759.fixed
@@ -1,1 +1,1 @@
-Fixes Repositories not syncing in single jobs due to a change in the Job class API #5692
+Fixes Repositories not syncing in single jobs due to a change in the Job class API #5692.

--- a/development/docker-compose.mysql.yml
+++ b/development/docker-compose.mysql.yml
@@ -19,7 +19,6 @@ services:
   db:
     image: "mysql:8"
     command:
-      - "--default-authentication-plugin=mysql_native_password"
       - "--max_connections=1000"
     env_file:
       - "development.env"

--- a/nautobot_golden_config/tests/test_jobs.py
+++ b/nautobot_golden_config/tests/test_jobs.py
@@ -79,7 +79,7 @@ class GCReposBackupTestCase(TransactionTestCase):
             module="nautobot_golden_config.jobs", name="BackupJob", device=Device.objects.filter(name=self.device.name)
         )
         log_entries = JobLogEntry.objects.filter(job_result=job_result, grouping="GC Repo Syncs")
-        self.assertEqual(log_entries.first().message, "Repository types to sync: ")
+        self.assertEqual(log_entries.first().message, "Repository types to sync: backup_repository")
 
         log_entries = JobLogEntry.objects.filter(job_result=job_result, grouping="Get Job Filter")
         self.assertEqual(log_entries.count(), 2)
@@ -97,7 +97,7 @@ class GCReposBackupTestCase(TransactionTestCase):
             module="nautobot_golden_config.jobs", name="BackupJob", device=Device.objects.all()
         )
         log_entries = JobLogEntry.objects.filter(job_result=job_result, grouping="GC Repo Syncs")
-        self.assertEqual(log_entries.first().message, "Repository types to sync: ")
+        self.assertEqual(log_entries.first().message, "Repository types to sync: backup_repository")
 
         log_entries = JobLogEntry.objects.filter(job_result=job_result, grouping="Get Job Filter")
         self.assertEqual(log_entries.count(), 2)
@@ -173,7 +173,7 @@ class GCReposIntendedTestCase(TransactionTestCase):
             device=Device.objects.filter(name=self.device.name),
         )
         log_entries = JobLogEntry.objects.filter(job_result=job_result, grouping="GC Repo Syncs")
-        self.assertEqual(log_entries.first().message, "Repository types to sync: ")
+        self.assertEqual(log_entries.first().message, "Repository types to sync: intended_repository, jinja_repository")
 
         log_entries = JobLogEntry.objects.filter(job_result=job_result, grouping="Get Job Filter")
         self.assertEqual(log_entries.count(), 2)
@@ -195,7 +195,7 @@ class GCReposIntendedTestCase(TransactionTestCase):
         self.assertEqual(log_entries.last().message, "In scope device count for this job: 2")
 
         log_entries = JobLogEntry.objects.filter(job_result=job_result, grouping="GC Repo Syncs")
-        self.assertEqual(log_entries.first().message, "Repository types to sync: ")
+        self.assertEqual(log_entries.first().message, "Repository types to sync: intended_repository, jinja_repository")
 
         log_entries = JobLogEntry.objects.filter(job_result=job_result, grouping="run")
         self.assertEqual(log_entries.last().message, "Intended Generation is disabled in application settings.")
@@ -271,7 +271,9 @@ class GCReposComplianceTestCase(TransactionTestCase):
             device=Device.objects.filter(name=self.device.name),
         )
         log_entries = JobLogEntry.objects.filter(job_result=job_result, grouping="GC Repo Syncs")
-        self.assertEqual(log_entries.first().message, "Repository types to sync: ")
+        self.assertEqual(
+            log_entries.first().message, "Repository types to sync: backup_repository, intended_repository"
+        )
 
         log_entries = JobLogEntry.objects.filter(job_result=job_result, grouping="Get Job Filter")
         self.assertEqual(log_entries.count(), 2)
@@ -293,7 +295,9 @@ class GCReposComplianceTestCase(TransactionTestCase):
         self.assertEqual(log_entries.last().message, "In scope device count for this job: 2")
 
         log_entries = JobLogEntry.objects.filter(job_result=job_result, grouping="GC Repo Syncs")
-        self.assertEqual(log_entries.first().message, "Repository types to sync: ")
+        self.assertEqual(
+            log_entries.first().message, "Repository types to sync: backup_repository, intended_repository"
+        )
 
         log_entries = JobLogEntry.objects.filter(job_result=job_result, grouping="run")
         self.assertEqual(log_entries.last().message, "Compliance is disabled in application settings.")


### PR DESCRIPTION
This update addresses changes in the Job API class in version 2.2.3 (see [#5692](https://github.com/nautobot/nautobot/pull/5692) for details). 

There's a slight change in behavior: if the `ENABLE*` settings are set to `False` and a single job is run, an initial sync on the repo will still occur. This is consistent with the behavior of `All Jobs`, so it should not cause any issues.