### PR TITLE
Updated django-pivot to ~1.9.0

### DIFF
--- a/changes/769.dependencies
+++ b/changes/769.dependencies
@@ -1,0 +1,1 @@
+Updated django-pivot to ~1.9.0.

--- a/changes/769.housekeeping
+++ b/changes/769.housekeeping
@@ -1,0 +1,1 @@
+Added view tests for ConfigComplianceUIViewSet.

--- a/nautobot_golden_config/api/serializers.py
+++ b/nautobot_golden_config/api/serializers.py
@@ -1,4 +1,5 @@
 """REST API serializer capabilities for graphql app."""
+
 # pylint: disable=too-many-ancestors
 from rest_framework import serializers
 
@@ -93,7 +94,7 @@ class ConfigToPushSerializer(DeviceSerializer):
 
     config = serializers.SerializerMethodField()
 
-    class Meta(DeviceSerializer):
+    class Meta(DeviceSerializer.Meta):
         """Extend the Device serializer with the configuration after postprocessing."""
 
         fields = "__all__"

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -453,7 +453,7 @@ class GenerateConfigPlans(Job, FormEntry):
     def _generate_config_plan_from_manual(self):
         """Generate config plans from manual."""
         default_context = {
-            "request": self.request,
+            "request": self.request,  # pylint: disable=no-member
             "user": self.user,
         }
         for device in self._device_qs:

--- a/nautobot_golden_config/nornir_plays/config_compliance.py
+++ b/nautobot_golden_config/nornir_plays/config_compliance.py
@@ -112,8 +112,7 @@ def diff_files(backup_file, intended_file):
     with open(intended_file, encoding="utf-8") as file:
         intended = file.readlines()
 
-    for line in difflib.unified_diff(backup, intended, lineterm=""):
-        yield line
+    yield from difflib.unified_diff(backup, intended, lineterm="")
 
 
 @close_threaded_db_connections

--- a/nautobot_golden_config/tests/test_views.py
+++ b/nautobot_golden_config/tests/test_views.py
@@ -7,9 +7,10 @@ from lxml import html
 
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase
+from django.test import override_settings, RequestFactory, TestCase
 from django.urls import reverse
 
+from nautobot.core.models.querysets import RestrictedQuerySet
 from nautobot.dcim.models import Device
 from nautobot.extras.models import Relationship, RelationshipAssociation, Status
 from nautobot.core.testing import ViewTestCases
@@ -350,3 +351,67 @@ class ConfigPlanTestCase(
     @skip("TODO: 2.0 Figure out how to have pass.")
     def test_list_objects_with_constrained_permission(self):
         pass
+
+
+@override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+class ConfigComplianceUIViewSetTestCase(
+    ViewTestCases.BulkDeleteObjectsViewTestCase,
+    # ViewTestCases.ListObjectsViewTestCase,  # generic list view tests won't work for this view since the queryset is pivoted
+):
+    """Test ConfigComplianceUIViewSet views."""
+
+    model = models.ConfigCompliance
+
+    @classmethod
+    def setUpTestData(cls):
+        create_device_data()
+        dev01 = Device.objects.get(name="Device 1")
+        dev02 = Device.objects.get(name="Device 2")
+        dev03 = Device.objects.get(name="Device 3")
+        dev04 = Device.objects.get(name="Device 4")
+
+        for i in range(4):
+            feature_dev01 = create_feature_rule_json(dev01, feature=f"TestFeature{i}")
+            feature_dev02 = create_feature_rule_json(dev02, feature=f"TestFeature{i}")
+            feature_dev03 = create_feature_rule_json(dev03, feature=f"TestFeature{i}")
+
+            updates = [
+                {"device": dev01, "feature": feature_dev01},
+                {"device": dev02, "feature": feature_dev02},
+                {"device": dev03, "feature": feature_dev03},
+                {"device": dev04, "feature": feature_dev01},
+            ]
+            for i, update in enumerate(updates):
+                compliance_int = i % 2
+                models.ConfigCompliance.objects.create(
+                    device=update["device"],
+                    rule=update["feature"],
+                    actual={"foo": {"bar-1": "baz"}},
+                    intended={"foo": {f"bar-{compliance_int}": "baz"}},
+                    compliance=bool(compliance_int),
+                    compliance_int=compliance_int,
+                )
+
+    def test_alter_queryset(self):
+        """Test alter_queryset method returns the expected pivoted queryset."""
+
+        unused_features = (
+            models.ComplianceFeature.objects.create(slug="unused-feature-1", name="Unused Feature 1"),
+            models.ComplianceFeature.objects.create(slug="unused-feature-2", name="Unused Feature 2"),
+        )
+        request = RequestFactory(SERVER_NAME="nautobot.example.com").get("/plugins/golden-config/config-compliance/")
+        request.user = self.user
+        queryset = views.ConfigComplianceUIViewSet(request=request).alter_queryset(request)
+        features = (
+            models.ComplianceFeature.objects.filter(feature__rule__isnull=False)
+            .values_list("slug", flat=True)
+            .distinct()
+        )
+        self.assertNotIn(unused_features[0].slug, features)
+        self.assertNotIn(unused_features[1].slug, features)
+        self.assertGreater(len(features), 0)
+        self.assertIsInstance(queryset, RestrictedQuerySet)
+        for device in queryset:
+            self.assertSequenceEqual(list(device.keys()), ["device", "device__name", *features])
+            for feature in features:
+                self.assertIn(device[feature], [0, 1])

--- a/nautobot_golden_config/tests/test_views.py
+++ b/nautobot_golden_config/tests/test_views.py
@@ -381,8 +381,8 @@ class ConfigComplianceUIViewSetTestCase(
                 {"device": dev03, "feature": feature_dev03},
                 {"device": dev04, "feature": feature_dev01},
             ]
-            for i, update in enumerate(updates):
-                compliance_int = i % 2
+            for j, update in enumerate(updates):
+                compliance_int = j % 2
                 models.ConfigCompliance.objects.create(
                     device=update["device"],
                     rule=update["feature"],

--- a/nautobot_golden_config/tests/test_views.py
+++ b/nautobot_golden_config/tests/test_views.py
@@ -399,7 +399,9 @@ class ConfigComplianceUIViewSetTestCase(
             models.ComplianceFeature.objects.create(slug="unused-feature-1", name="Unused Feature 1"),
             models.ComplianceFeature.objects.create(slug="unused-feature-2", name="Unused Feature 2"),
         )
-        request = RequestFactory(SERVER_NAME="nautobot.example.com").get("/plugins/golden-config/config-compliance/")
+        request = RequestFactory(SERVER_NAME="nautobot.example.com").get(
+            reverse("plugins:nautobot_golden_config:configcompliance_list")
+        )
         request.user = self.user
         queryset = views.ConfigComplianceUIViewSet(request=request).alter_queryset(request)
         features = (

--- a/nautobot_golden_config/tests/test_views.py
+++ b/nautobot_golden_config/tests/test_views.py
@@ -370,10 +370,10 @@ class ConfigComplianceUIViewSetTestCase(
         dev03 = Device.objects.get(name="Device 3")
         dev04 = Device.objects.get(name="Device 4")
 
-        for i in range(4):
-            feature_dev01 = create_feature_rule_json(dev01, feature=f"TestFeature{i}")
-            feature_dev02 = create_feature_rule_json(dev02, feature=f"TestFeature{i}")
-            feature_dev03 = create_feature_rule_json(dev03, feature=f"TestFeature{i}")
+        for iterator_i in range(4):
+            feature_dev01 = create_feature_rule_json(dev01, feature=f"TestFeature{iterator_i}")
+            feature_dev02 = create_feature_rule_json(dev02, feature=f"TestFeature{iterator_i}")
+            feature_dev03 = create_feature_rule_json(dev03, feature=f"TestFeature{iterator_i}")
 
             updates = [
                 {"device": dev01, "feature": feature_dev01},
@@ -381,8 +381,8 @@ class ConfigComplianceUIViewSetTestCase(
                 {"device": dev03, "feature": feature_dev03},
                 {"device": dev04, "feature": feature_dev01},
             ]
-            for j, update in enumerate(updates):
-                compliance_int = j % 2
+            for iterator_j, update in enumerate(updates):
+                compliance_int = iterator_j % 2
                 models.ConfigCompliance.objects.create(
                     device=update["device"],
                     rule=update["feature"],

--- a/poetry.lock
+++ b/poetry.lock
@@ -1126,18 +1126,17 @@ tests = ["tox"]
 
 [[package]]
 name = "django-pivot"
-version = "1.8.1"
+version = "1.9.0"
 description = "Create pivot tables and histograms from ORM querysets"
 optional = false
 python-versions = "*"
 files = [
-    {file = "django-pivot-1.8.1.tar.gz", hash = "sha256:7184d3e3f5e96003150428bea106a9963f49f0431fa56f93595316c9b42bcca6"},
-    {file = "django_pivot-1.8.1-py3-none-any.whl", hash = "sha256:9bf83b2b61d4dc95c01e5b7a595ee223c5c1f08a4590733673a306b1513174d4"},
+    {file = "django-pivot-1.9.0.tar.gz", hash = "sha256:5e985d32d9ff2a6b89419dd0292c0fa2822d494ee479b5fd16cdb542abf66a88"},
+    {file = "django_pivot-1.9.0-py3-none-any.whl", hash = "sha256:1c60e18e7d5f7e42856faee0961748082ddd05b01ae7c8a4baed64d2bbacd051"},
 ]
 
 [package.dependencies]
-django = ">=1.10"
-six = "*"
+django = ">=2.2.0"
 
 [[package]]
 name = "django-prometheus"
@@ -4838,4 +4837,4 @@ all = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "20172d3408f0d068d72749f472aa20eca0102ac1a872685d11e1e324413f233e"
+content-hash = "3320a0e8fced27e6dac2b0239c9067d73b8e91fe394da3c482543b5beb8ebade"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ include = [
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
 deepdiff = ">=5.5.0,!=6.0,!=6.1,<8"
-django-pivot = "1.8.1" # The signature changed to return a non-queryset, do not upgrade without ensuring it returns a queryset
+django-pivot = ">=1.9.0,<1.10.0" # The signature changed to return a non-queryset, do not upgrade without ensuring it returns a queryset
 matplotlib = "^3.3.2"
 nautobot-plugin-nornir = "^2.0.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,9 +116,6 @@ disable = """,
     line-too-long,
     too-few-public-methods,
     duplicate-code,
-    nb-no-model-found,
-    nb-sub-class-name,
-    nb-use-fields-all,
     """
 
 [tool.pylint.miscellaneous]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,9 @@ disable = """,
     line-too-long,
     too-few-public-methods,
     duplicate-code,
+    nb-no-model-found,
+    nb-sub-class-name,
+    nb-use-fields-all,
     """
 
 [tool.pylint.miscellaneous]


### PR DESCRIPTION
Closes #769 

Kicking this down the road a bit by not vendoring the package, since django_pivot 1.9.0 supports django 4 and the breaking change in django_pivot wasn't made until 1.10.0. However the test I added will help us to vendor django_pivot later if necessary.