### PR TITLE
789 - Collapsible panels

### DIFF
--- a/nautobot_golden_config/static/config_compliance_layout.js
+++ b/nautobot_golden_config/static/config_compliance_layout.js
@@ -1,0 +1,31 @@
+// Enables panels on homepage to be collapsed and expanded
+document.addEventListener("DOMContentLoaded", function() {
+    // Function to toggle and save state for a specific collapsible element
+    function toggleAndSaveState(elementId) {
+        // Remove "toggle-" in the ID to get the localStorage key the toggle btn references
+        elementId = elementId.replace("toggle-", "");
+        var collapsibleDiv = document.getElementById(elementId);
+
+        // Toggle the collapsed class
+        var isCollapsed = collapsibleDiv.classList.toggle("collapsed")
+
+        // Update the state in localStorage
+        var isCollapsed = collapsibleDiv.classList.contains("in");
+        localStorage.setItem(elementId, isCollapsed ? "collapsed" : "expanded");
+        // Set Cookie value based on isCollapsed
+        if (isCollapsed) {
+            document.cookie = elementId + "=True; path=/";
+        } else {
+            document.cookie = elementId + "=False; path=/";
+        }
+    }
+
+    // Add event listener to each collapsible div
+    var collapseIcons = document.querySelectorAll(".collapse-icon");
+    collapseIcons.forEach(function(icon) {
+        icon.addEventListener("click", function() {
+            var elementId = this.id;
+            toggleAndSaveState(elementId);
+        });
+    });
+});

--- a/nautobot_golden_config/static/config_compliance_layout.js
+++ b/nautobot_golden_config/static/config_compliance_layout.js
@@ -9,6 +9,11 @@ document.addEventListener("DOMContentLoaded", function() {
         // Toggle the collapsed class
         var isCollapsed = collapsibleDiv.classList.toggle("collapsed")
 
+        // Retrieve glyphicon
+        var icon = document.getElementById("collapse-icon-" + elementId);
+        // Rotate glyphicon
+        icon.classList.toggle("rotated");
+
         // Update the state in localStorage
         var isCollapsed = collapsibleDiv.classList.contains("in");
         localStorage.setItem(elementId, isCollapsed ? "collapsed" : "expanded");
@@ -21,7 +26,7 @@ document.addEventListener("DOMContentLoaded", function() {
     }
 
     // Add event listener to each collapsible div
-    var collapseIcons = document.querySelectorAll(".collapse-icon");
+    var collapseIcons = document.querySelectorAll(".collapsable-heading");
     collapseIcons.forEach(function(icon) {
         icon.addEventListener("click", function() {
             var elementId = this.id;

--- a/nautobot_golden_config/templates/nautobot_golden_config/configcompliance_devicetab.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/configcompliance_devicetab.html
@@ -61,6 +61,9 @@
     .collapse-icon {
         transition: transform 0.3s ease;
     }
+    .collapsable-heading:hover {
+        cursor: pointer;
+    }
 </style>
 <noscript>
     <style>
@@ -106,7 +109,7 @@
         {% with cookie_key='configcompliance-'|add:item_rule %}
         <div id="toggle-configcompliance-{{ item_rule }}" class="panel-heading collapsable-heading" type="button" data-toggle="collapse" data-target="#configcompliance-{{ item_rule }}" aria-expanded="false" aria-controls="configcompliance-{{ item_rule }}">
             <strong><a href="{% url 'plugins:nautobot_golden_config:configcompliance' pk=item.pk %}">{{ item.rule.feature.name|upper }}</a></strong>
-            <i id="collapse-icon-configcompliance-{{ item_rule }}" class="glyphicon glyphicon-chevron-down collapse-icon{% if request.COOKIES|default:''|get_item:cookie_key|default:'False' == 'False' %} rotated{% endif %}"></i>
+            <span id="collapse-icon-configcompliance-{{ item_rule }}" class="glyphicon glyphicon-chevron-down collapse-icon{% if request.COOKIES|default:''|get_item:cookie_key|default:'False' == 'False' %} rotated{% endif %}"></span>
         </div>
         <div class="list-group collapse{% if request.COOKIES|default:''|get_item:cookie_key|default:'False' == 'False' %} in{% endif %} collapsible-div" id="configcompliance-{{ item_rule }}">
         {% endwith %}

--- a/nautobot_golden_config/templates/nautobot_golden_config/configcompliance_devicetab.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/configcompliance_devicetab.html
@@ -55,7 +55,20 @@
     #navigation td:hover{
         transform: scale(1.1);
     }
+    .rotated {
+        transform: rotate(180deg);
+    }
+    .collapse-icon {
+        transition: transform 0.3s ease;
+    }
 </style>
+<noscript>
+    <style>
+        .collapse-icon {
+            display: none;
+        }
+    </style>
+</noscript>
 {% block navigation %}
 <div class="panel panel-default" style="width:100%">
         <div class="panel-heading"><strong>Feature Navigation</strong> 
@@ -64,17 +77,17 @@
             <a href="{% url 'plugins:nautobot_golden_config:configcompliance_devicetab' pk=device.pk %}?tab={{ active_tab }}" class="btn btn-info">Clear</a>  
         </div>
     <div id="navigation">
-        <table>
+        <table border="1" cellspacing="0" cellpadding="0">
             <tr>
             {% for item in compliance_details %}
+                <td style="padding: 3px;">
                 {% if item.compliance %}
-                    <td style="background-color: #5cb85c;">
+                    <div style="background-color: #15a030; border-radius: 10px; padding: 10px; margin: 3px;">
                 {% else %}
-                    <td style="background-color: #d9534f;">
+                    <div style="background-color: #e02020; border-radius: 10px; padding: 10px; margin: 3px;">
                 {% endif %}
-                    <a href="#{{ item.rule }}">
-                        {{ item.rule }}
-                    </a>
+                        <a href="#{{ item.rule }}">{{ item.rule }}</a>
+                    </div>
                 </td>
                 {% if forloop.counter|divisibleby:"5" %}
                     </tr>
@@ -90,12 +103,12 @@
 {% for item in compliance_details %}
     {% with item_rule=item.rule|slugify %}
     <div id="{{ item_rule }}" class="panel panel-default" style="width:100%">
-        <div class="panel-heading">
-            <strong><a href="{% url 'plugins:nautobot_golden_config:configcompliance' pk=item.pk %}">{{ item.rule.feature.name|upper }}</a></strong>
-            <span id="toggle-configcompliance-{{ item_rule }}" class="glyphicon glyphicon-chevron-down collapse-icon" type="button" data-toggle="collapse" data-target="#configcompliance-{{ item_rule }}" aria-expanded="false" aria-controls="configcompliance-{{ item_rule }}"></span>
-        </div>
         {% with cookie_key='configcompliance-'|add:item_rule %}
-        <div class="list-group collapse{% if request.COOKIES|default:''|get_item:cookie_key|default:'False' == 'False' %} in{% endif %} collapsible-div" id="configcompliance-{{ item_rule }}" >
+        <div id="toggle-configcompliance-{{ item_rule }}" class="panel-heading collapsable-heading" type="button" data-toggle="collapse" data-target="#configcompliance-{{ item_rule }}" aria-expanded="false" aria-controls="configcompliance-{{ item_rule }}">
+            <strong><a href="{% url 'plugins:nautobot_golden_config:configcompliance' pk=item.pk %}">{{ item.rule.feature.name|upper }}</a></strong>
+            <i id="collapse-icon-configcompliance-{{ item_rule }}" class="glyphicon glyphicon-chevron-down collapse-icon{% if request.COOKIES|default:''|get_item:cookie_key|default:'False' == 'False' %} rotated{% endif %}"></i>
+        </div>
+        <div class="list-group collapse{% if request.COOKIES|default:''|get_item:cookie_key|default:'False' == 'False' %} in{% endif %} collapsible-div" id="configcompliance-{{ item_rule }}">
         {% endwith %}
             <table id="compliance-content">
             <tr>
@@ -120,14 +133,14 @@
                     <td style="width:250px">Configuration</td>
                     <td class="config_hover">
                         {% if item.rule.config_type == "xml" %}
-                            <span id="{{ item.rule|slugify }}_actual"><pre><code class="language-xml">{{ item.actual|placeholder }}</code></pre></span>
+                            <span id="{{ item_rule }}_actual"><pre><code class="language-xml">{{ item.actual|placeholder }}</code></pre></span>
                         {% elif item.rule.config_type == "json" %}
-                            <span id="{{ item.rule|slugify }}_actual"><pre><code class="language-json">{{ item.actual|placeholder|condition_render_json }}</code></pre></span>
+                            <span id="{{ item_rule }}_actual"><pre><code class="language-json">{{ item.actual|placeholder|condition_render_json }}</code></pre></span>
                         {% else %}
-                            <span id="{{ item.rule|slugify }}_actual"><pre>{{ item.actual|placeholder }}</pre></span>
+                            <span id="{{ item_rule }}_actual"><pre>{{ item.actual|placeholder }}</pre></span>
                         {% endif %}
                         <span class="config_hover_button">
-                            <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_actual">
+                            <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item_rule }}_actual">
                                 <span class="mdi mdi-content-copy"></span>
                             </button>
                         </span>
@@ -138,14 +151,14 @@
                     <td style="width:250px">Intended Configuration</td>
                     <td class="config_hover">
                         {% if item.rule.config_type == "xml" %}
-                            <span id="{{ item.rule|slugify }}_intended"><pre><code class="language-xml">{{ item.intended|placeholder }}</code></pre></span>
+                            <span id="{{ item_rule }}_intended"><pre><code class="language-xml">{{ item.intended|placeholder }}</code></pre></span>
                         {% elif item.rule.config_type == "json" %}
-                            <span id="{{ item.rule|slugify }}_intended"><pre><code class="language-json">{{ item.intended|placeholder|condition_render_json }}</code></pre></span>
+                            <span id="{{ item_rule }}_intended"><pre><code class="language-json">{{ item.intended|placeholder|condition_render_json }}</code></pre></span>
                         {% else %}
-                            <span id="{{ item.rule|slugify }}_intended"><pre>{{ item.intended|placeholder }}</pre></span>
+                            <span id="{{ item_rule }}_intended"><pre>{{ item.intended|placeholder }}</pre></span>
                         {% endif %}
                         <span class="config_hover_button">
-                            <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_intended">
+                            <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item_rule }}_intended">
                                 <span class="mdi mdi-content-copy"></span>
                             </button>
                         </span>
@@ -155,14 +168,14 @@
                     <td style="width:250px">Actual Configuration</td>
                     <td class="config_hover">
                         {% if item.rule.config_type == "xml" %}
-                            <span id="{{ item.rule|slugify }}_actual"><pre><code class="language-xml">{{ item.actual|placeholder }}</code></pre></span>
+                            <span id="{{ item_rule }}_actual"><pre><code class="language-xml">{{ item.actual|placeholder }}</code></pre></span>
                         {% elif item.rule.config_type == "json" %}
-                            <span id="{{ item.rule|slugify }}_actual"><pre><code class="language-json">{{ item.actual|placeholder|condition_render_json }}</code></pre></span>
+                            <span id="{{ item_rule }}_actual"><pre><code class="language-json">{{ item.actual|placeholder|condition_render_json }}</code></pre></span>
                         {% else %}
-                            <span id="{{ item.rule|slugify }}_actual"><pre>{{ item.actual|placeholder }}</pre></span>
+                            <span id="{{ item_rule }}_actual"><pre>{{ item.actual|placeholder }}</pre></span>
                         {% endif %}
                         <span class="config_hover_button">
-                            <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_actual">
+                            <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item_rule }}_actual">
                                 <span class="mdi mdi-content-copy"></span>
                             </button>
                         </span>
@@ -173,9 +186,9 @@
                 <tr>
                     <td style="color:red;width:250px">Missing Configuration</td>
                     <td class="config_hover">
-                        <span id="{{ item.rule|slugify }}_missing"><pre>{{ item.missing|condition_render_json }}</pre></span>
+                        <span id="{{ item_rule }}_missing"><pre>{{ item.missing|condition_render_json }}</pre></span>
                         <span class="config_hover_button">
-                            <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_missing">
+                            <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item_rule }}_missing">
                                 <span class="mdi mdi-content-copy"></span>
                             </button>
                         </span>
@@ -186,9 +199,9 @@
                 <tr>
                     <td style="color:red;width:250px">Extra Configuration</td>
                     <td class="config_hover">
-                        <span id="{{ item.rule|slugify }}_extra"><pre>{{ item.extra|condition_render_json }}</pre></span>
+                        <span id="{{ item_rule }}_extra"><pre>{{ item.extra|condition_render_json }}</pre></span>
                         <span class="config_hover_button">
-                            <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_extra">
+                            <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item_rule }}_extra">
                                 <span class="mdi mdi-content-copy"></span>
                             </button>
                         </span>
@@ -199,9 +212,9 @@
             <tr>
                 <td style="color:red;width:250px">Remediating Configuration</td>
                 <td class="config_hover">
-                    <span id="{{ item.rule|slugify }}_remediation"><pre>{{ item.remediation|condition_render_json }}</pre></span>
+                    <span id="{{ item_rule }}_remediation"><pre>{{ item.remediation|condition_render_json }}</pre></span>
                     <span class="config_hover_button">
-                        <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_remediation">
+                        <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item_rule }}_remediation">
                             <span class="mdi mdi-content-copy"></span>
                         </button>
                     </span>

--- a/nautobot_golden_config/templates/nautobot_golden_config/configcompliance_devicetab.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/configcompliance_devicetab.html
@@ -86,121 +86,137 @@
     </div>
 </div>
 {% endblock %}
+<div class="homepage_column" id="draggable-configcompliance-panels">
 {% for item in compliance_details %}
-    <div id="{{ item.rule }}" class="panel panel-default" style="width:100%">
-        <div class="panel-heading"><strong><a href="{% url 'plugins:nautobot_golden_config:configcompliance' pk=item.pk %}">{{ item.rule.feature.name|upper }}</a></strong></div>
-        <table id="compliance-content">
-        <tr>
-            <td style="width:250px">Status</td>
-            {% if item.rule.config_ordered %}
-                {% if item.compliance %}
-                    <td><span class="label label-success">Compliant</span> <span><i class="mdi mdi-sort" title="Ordered Configuration Test"></i></span></td>
+    {% with item_rule=item.rule|slugify %}
+    <div id="{{ item_rule }}" class="panel panel-default" style="width:100%">
+        <div class="panel-heading">
+            <strong><a href="{% url 'plugins:nautobot_golden_config:configcompliance' pk=item.pk %}">{{ item.rule.feature.name|upper }}</a></strong>
+            <span id="toggle-configcompliance-{{ item_rule }}" class="glyphicon glyphicon-chevron-down collapse-icon" type="button" data-toggle="collapse" data-target="#configcompliance-{{ item_rule }}" aria-expanded="false" aria-controls="configcompliance-{{ item_rule }}"></span>
+        </div>
+        {% with cookie_key='configcompliance-'|add:item_rule %}
+        <div class="list-group collapse{% if request.COOKIES|default:''|get_item:cookie_key|default:'False' == 'False' %} in{% endif %} collapsible-div" id="configcompliance-{{ item_rule }}" >
+        {% endwith %}
+            <table id="compliance-content">
+            <tr>
+                <td style="width:250px">Status</td>
+                {% if item.rule.config_ordered %}
+                    {% if item.compliance %}
+                        <td><span class="label label-success">Compliant</span> <span><i class="mdi mdi-sort" title="Ordered Configuration Test"></i></span></td>
+                    {% else %}
+                        <td><span class="label label-danger">Non-Compliant</span> <span><i class="mdi mdi-sort" title="Ordered Configuration Test"></i></span></td>
+                    {% endif %}
                 {% else %}
-                    <td><span class="label label-danger">Non-Compliant</span> <span><i class="mdi mdi-sort" title="Ordered Configuration Test"></i></span></td>
+                    {% if item.compliance %}
+                        <td><span class="label label-success">Compliant</span> <span><i class="mdi mdi-swap-vertical" title="Unordered Configuration Test"></i></span></td>
+                    {% else %}
+                        <td><span class="label label-danger">Non-Compliant</span> <span><i class="mdi mdi-swap-vertical" title="Unordered Configuration Test"></i></span></td>
+                    {% endif %}
                 {% endif %}
-            {% else %}
-                {% if item.compliance %}
-                    <td><span class="label label-success">Compliant</span> <span><i class="mdi mdi-swap-vertical" title="Unordered Configuration Test"></i></span></td>
-                {% else %}
-                    <td><span class="label label-danger">Non-Compliant</span> <span><i class="mdi mdi-swap-vertical" title="Unordered Configuration Test"></i></span></td>
-                {% endif %}
-            {% endif %}
 
-        </tr>
-        {% if item.ordered %}
-            <tr>
-                <td style="width:250px">Configuration</td>
-                <td class="config_hover">
-                    {% if item.rule.config_type == "xml" %}
-                        <span id="{{ item.rule|slugify }}_actual"><pre><code class="language-xml">{{ item.actual|placeholder }}</code></pre></span>
-                    {% elif item.rule.config_type == "json" %}
-                        <span id="{{ item.rule|slugify }}_actual"><pre><code class="language-json">{{ item.actual|placeholder|condition_render_json }}</code></pre></span>
-                    {% else %}
-                        <span id="{{ item.rule|slugify }}_actual"><pre>{{ item.actual|placeholder }}</pre></span>
-                    {% endif %}
-                    <span class="config_hover_button">
-                        <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_actual">
-                            <span class="mdi mdi-content-copy"></span>
-                        </button>
-                    </span>
-                </td>
             </tr>
-        {% else %}
+            {% if item.ordered %}
+                <tr>
+                    <td style="width:250px">Configuration</td>
+                    <td class="config_hover">
+                        {% if item.rule.config_type == "xml" %}
+                            <span id="{{ item.rule|slugify }}_actual"><pre><code class="language-xml">{{ item.actual|placeholder }}</code></pre></span>
+                        {% elif item.rule.config_type == "json" %}
+                            <span id="{{ item.rule|slugify }}_actual"><pre><code class="language-json">{{ item.actual|placeholder|condition_render_json }}</code></pre></span>
+                        {% else %}
+                            <span id="{{ item.rule|slugify }}_actual"><pre>{{ item.actual|placeholder }}</pre></span>
+                        {% endif %}
+                        <span class="config_hover_button">
+                            <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_actual">
+                                <span class="mdi mdi-content-copy"></span>
+                            </button>
+                        </span>
+                    </td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td style="width:250px">Intended Configuration</td>
+                    <td class="config_hover">
+                        {% if item.rule.config_type == "xml" %}
+                            <span id="{{ item.rule|slugify }}_intended"><pre><code class="language-xml">{{ item.intended|placeholder }}</code></pre></span>
+                        {% elif item.rule.config_type == "json" %}
+                            <span id="{{ item.rule|slugify }}_intended"><pre><code class="language-json">{{ item.intended|placeholder|condition_render_json }}</code></pre></span>
+                        {% else %}
+                            <span id="{{ item.rule|slugify }}_intended"><pre>{{ item.intended|placeholder }}</pre></span>
+                        {% endif %}
+                        <span class="config_hover_button">
+                            <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_intended">
+                                <span class="mdi mdi-content-copy"></span>
+                            </button>
+                        </span>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="width:250px">Actual Configuration</td>
+                    <td class="config_hover">
+                        {% if item.rule.config_type == "xml" %}
+                            <span id="{{ item.rule|slugify }}_actual"><pre><code class="language-xml">{{ item.actual|placeholder }}</code></pre></span>
+                        {% elif item.rule.config_type == "json" %}
+                            <span id="{{ item.rule|slugify }}_actual"><pre><code class="language-json">{{ item.actual|placeholder|condition_render_json }}</code></pre></span>
+                        {% else %}
+                            <span id="{{ item.rule|slugify }}_actual"><pre>{{ item.actual|placeholder }}</pre></span>
+                        {% endif %}
+                        <span class="config_hover_button">
+                            <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_actual">
+                                <span class="mdi mdi-content-copy"></span>
+                            </button>
+                        </span>
+                    </td>
+                </tr>
+            {% endif %}
+            {% if item.missing != "" %}
+                <tr>
+                    <td style="color:red;width:250px">Missing Configuration</td>
+                    <td class="config_hover">
+                        <span id="{{ item.rule|slugify }}_missing"><pre>{{ item.missing|condition_render_json }}</pre></span>
+                        <span class="config_hover_button">
+                            <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_missing">
+                                <span class="mdi mdi-content-copy"></span>
+                            </button>
+                        </span>
+                    </td>
+                </tr>
+            {% endif %}
+            {% if item.extra != "" %}
+                <tr>
+                    <td style="color:red;width:250px">Extra Configuration</td>
+                    <td class="config_hover">
+                        <span id="{{ item.rule|slugify }}_extra"><pre>{{ item.extra|condition_render_json }}</pre></span>
+                        <span class="config_hover_button">
+                            <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_extra">
+                                <span class="mdi mdi-content-copy"></span>
+                            </button>
+                        </span>
+                    </td>
+                </tr>
+            {% endif %}
+            {% if item.remediation != "" %}
             <tr>
-                <td style="width:250px">Intended Configuration</td>
+                <td style="color:red;width:250px">Remediating Configuration</td>
                 <td class="config_hover">
-                    {% if item.rule.config_type == "xml" %}
-                        <span id="{{ item.rule|slugify }}_intended"><pre><code class="language-xml">{{ item.intended|placeholder }}</code></pre></span>
-                    {% elif item.rule.config_type == "json" %}
-                        <span id="{{ item.rule|slugify }}_intended"><pre><code class="language-json">{{ item.intended|placeholder|condition_render_json }}</code></pre></span>
-                    {% else %}
-                        <span id="{{ item.rule|slugify }}_intended"><pre>{{ item.intended|placeholder }}</pre></span>
-                    {% endif %}
+                    <span id="{{ item.rule|slugify }}_remediation"><pre>{{ item.remediation|condition_render_json }}</pre></span>
                     <span class="config_hover_button">
-                        <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_intended">
-                            <span class="mdi mdi-content-copy"></span>
-                        </button>
-                    </span>
-                </td>
-            </tr>
-            <tr>
-                <td style="width:250px">Actual Configuration</td>
-                <td class="config_hover">
-                    {% if item.rule.config_type == "xml" %}
-                        <span id="{{ item.rule|slugify }}_actual"><pre><code class="language-xml">{{ item.actual|placeholder }}</code></pre></span>
-                    {% elif item.rule.config_type == "json" %}
-                        <span id="{{ item.rule|slugify }}_actual"><pre><code class="language-json">{{ item.actual|placeholder|condition_render_json }}</code></pre></span>
-                    {% else %}
-                        <span id="{{ item.rule|slugify }}_actual"><pre>{{ item.actual|placeholder }}</pre></span>
-                    {% endif %}
-                    <span class="config_hover_button">
-                        <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_actual">
+                        <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_remediation">
                             <span class="mdi mdi-content-copy"></span>
                         </button>
                     </span>
                 </td>
             </tr>
         {% endif %}
-        {% if item.missing != "" %}
-            <tr>
-                <td style="color:red;width:250px">Missing Configuration</td>
-                <td class="config_hover">
-                    <span id="{{ item.rule|slugify }}_missing"><pre>{{ item.missing|condition_render_json }}</pre></span>
-                    <span class="config_hover_button">
-                        <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_missing">
-                            <span class="mdi mdi-content-copy"></span>
-                        </button>
-                    </span>
-                </td>
-            </tr>
-        {% endif %}
-        {% if item.extra != "" %}
-            <tr>
-                <td style="color:red;width:250px">Extra Configuration</td>
-                <td class="config_hover">
-                    <span id="{{ item.rule|slugify }}_extra"><pre>{{ item.extra|condition_render_json }}</pre></span>
-                    <span class="config_hover_button">
-                        <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_extra">
-                            <span class="mdi mdi-content-copy"></span>
-                        </button>
-                    </span>
-                </td>
-            </tr>
-        {% endif %}
-        {% if item.remediation != "" %}
-        <tr>
-            <td style="color:red;width:250px">Remediating Configuration</td>
-            <td class="config_hover">
-                <span id="{{ item.rule|slugify }}_remediation"><pre>{{ item.remediation|condition_render_json }}</pre></span>
-                <span class="config_hover_button">
-                    <button class="btn btn-inline btn-default hover_copy_button" data-clipboard-target="#{{ item.rule|slugify }}_remediation">
-                        <span class="mdi mdi-content-copy"></span>
-                    </button>
-                </span>
-            </td>
-        </tr>
-    {% endif %}
-    </table>
+            </table>
+        </div>
     </div>
+    {% endwith %}
 {% endfor %}
+</div>
+{% endblock %}
+{% block javascript %}
+{{ block.super }}
+<script src="{% versioned_static 'config_compliance_layout.js' %}"
+        onerror="window.location='{% url 'media_failure' %}?filename=config_compliance_layout.js'"></script>
 {% endblock %}


### PR DESCRIPTION
This adds support for the Configuration Compliance panels on a Device page to be collapsible.

You can click anywhere on the panel heading and it will toggle between collapsed and expanded.  Settings are saved via local cookie.  This means that if you leave the page or refresh it, whatever you collapsed will remain collapsed.

These preferences are saved by platform and feature.  This means that if you collapse the AAA box for IOS, then all IOS AAA boxes will remain collapsed.  This can be changed if another method is preferred.

I've also updated the formatting slightly on the top green/red boxes to match the colors on the rest of the page.  The green and red now matches the greens on the other buttons/labels on the page.  I also made the boxes have slightly softer edges.

![Screenshot 2024-08-09 at 3 23 08 PM](https://github.com/user-attachments/assets/dd733ac8-0e09-4429-aa97-44efa675139f)
