### PR TITLE
Make the Git commit message configurable

### DIFF
--- a/changes/814.changed
+++ b/changes/814.changed
@@ -1,0 +1,1 @@
+Changed the Git commit message of GC Jobs to be configurable.

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -154,7 +154,7 @@ def gc_repo_push(job, current_repos, commit_message=""):
                 repo["repo_obj"].commit_with_added(commit_message)
                 repo["repo_obj"].push()
                 job.logger.info(
-                    f'The new Git repository hash is "{repo["repo_obj"].head}"',
+                    f'{repo["repo_obj"].nautobot_repo_obj.name}: the new Git repository hash is "{repo["repo_obj"].head}"',
                     extra={
                         "grouping": "GC Repo Commit and Push",
                         "object": repo["repo_obj"].nautobot_repo_obj,
@@ -212,6 +212,13 @@ class GoldenConfigJobMixin(Job):  # pylint: disable=abstract-method
     """Reused mixin to be able to set defaults for instance attributes in all GC jobs."""
 
     fail_job_on_task_failure = BooleanVar(description="If any tasks for any device fails, fail the entire job result.")
+    commit_message = StringVar(
+        label="Git commit message",
+        required=False,
+        description=r"If empty, defaults to `{job.Meta.name.upper()} JOB {now}`.",
+        min_length=2,
+        max_length=72,
+    )
 
     def __init__(self, *args, **kwargs):
         """Initialize the job."""
@@ -243,14 +250,6 @@ class ComplianceJob(GoldenConfigJobMixin, FormEntry):
 class IntendedJob(GoldenConfigJobMixin, FormEntry):
     """Job to to run generation of intended configurations."""
 
-    commit_message = StringVar(
-        label="Git commit message",
-        required=False,
-        description=r"If empty, defaults to `{job.Meta.name.upper()} JOB {now}`.",
-        min_length=2,
-        max_length=72,
-    )
-
     class Meta:
         """Meta object boilerplate for intended."""
 
@@ -270,14 +269,6 @@ class IntendedJob(GoldenConfigJobMixin, FormEntry):
 
 class BackupJob(GoldenConfigJobMixin, FormEntry):
     """Job to to run the backup job."""
-
-    commit_message = StringVar(
-        label="Git commit message",
-        required=False,
-        description=r"If empty, defaults to `{job.Meta.name.upper()} JOB {now}`.",
-        min_length=2,
-        max_length=72,
-    )
 
     class Meta:
         """Meta object boilerplate for backup configurations."""
@@ -301,14 +292,6 @@ class AllGoldenConfig(GoldenConfigJobMixin):
 
     device = ObjectVar(model=Device, required=True)
     debug = BooleanVar(description="Enable for more verbose debug logging")
-
-    commit_message = StringVar(
-        label="Git commit message",
-        required=False,
-        description=r"If empty, defaults to `{job.Meta.name.upper()} JOB {now}` - applies to both Backup and Intended.",
-        min_length=2,
-        max_length=72,
-    )
 
     class Meta:
         """Meta object boilerplate for all jobs to run against a device."""
@@ -358,14 +341,6 @@ class AllGoldenConfig(GoldenConfigJobMixin):
 
 class AllDevicesGoldenConfig(GoldenConfigJobMixin, FormEntry):
     """Job to to run all three jobs against multiple devices."""
-
-    commit_message = StringVar(
-        label="Git commit message",
-        required=False,
-        description=r"If empty, defaults to `{job.Meta.name.upper()} JOB {now}` - applies to both Backup and Intended.",
-        min_length=2,
-        max_length=72,
-    )
 
     class Meta:
         """Meta object boilerplate for all jobs to run against multiple devices."""

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -130,7 +130,7 @@ def gc_repo_prep(job, data):
     return current_repos
 
 
-def gc_repo_push(job, current_repos):
+def gc_repo_push(job, current_repos, commit_message):
     """Push any work from worker to git repos in Job.
 
     Args:
@@ -149,8 +149,14 @@ def gc_repo_push(job, current_repos):
                     f"Pushing {job.Meta.name} results to repo {repo['repo_obj'].base_url}.",
                     extra={"grouping": "GC Repo Commit and Push"},
                 )
-                repo["repo_obj"].commit_with_added(f"{job.Meta.name.upper()} JOB {now}")
+                if not commit_message:
+                    commit_message = f"{job.Meta.name.upper()} JOB {now}"
+                repo["repo_obj"].commit_with_added(commit_message)
                 repo["repo_obj"].push()
+                job.logger.info(
+                    f"HEAD {repo['repo_obj'].head}",
+                    extra={"grouping": "GC Repo Commit and Push", "object": repo["repo_obj"].nautobot_repo_obj},
+                )
 
 
 def gc_repos(func):
@@ -168,7 +174,7 @@ def gc_repos(func):
             if kwargs.get("fail_job_on_task_failure"):
                 raise NornirNautobotException(error_msg) from error
         finally:
-            gc_repo_push(job=self, current_repos=current_repos)
+            gc_repo_push(job=self, current_repos=current_repos, commit_message=kwargs.get("commit_message"))
 
     return gc_repo_wrapper
 
@@ -202,6 +208,14 @@ class FormEntry:  # pylint disable=too-few-public-method
 class GoldenConfigJobMixin(Job):  # pylint: disable=abstract-method
     """Reused mixin to be able to set defaults for instance attributes in all GC jobs."""
 
+    # TODO: verify if the "commit_message" should be kept here or should be moved to FormEntry
+    commit_message = StringVar(
+        label="Commit message",
+        required=False,
+        description=r"If empty, defaults to `{job.Meta.name.upper()} JOB {now}`.",
+        min_length=2,
+        max_length=72
+    )
     fail_job_on_task_failure = BooleanVar(description="If any tasks for any device fails, fail the entire job result.")
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
- Adds a `commit_message` field on the `Backup`, `Intended`, and `Execute All Golden Configuration Jobs` variants that allows the operator to define the Git commit message to be used.
![image](https://github.com/user-attachments/assets/5d161fcd-de0c-4ec6-aa5a-fa58fc106831)

.

- In alignment with the behavior of the core Nautobot `ensure_git_repository` function, the GC `gc_repo_push` function has been modified to log the Git repository HEAD hash after commits.
![image](https://github.com/user-attachments/assets/cdb4fac7-129c-4758-b3f4-86e158da3586)

Closes #814.