### PR TITLE
Resolved error when accessing the Golden Config Settings list view

### DIFF
--- a/changes/835.fixed
+++ b/changes/835.fixed
@@ -1,0 +1,1 @@
+Resolved error when accessing the Golden Config Settings list view.

--- a/nautobot_golden_config/models.py
+++ b/nautobot_golden_config/models.py
@@ -586,6 +586,7 @@ class GoldenConfigSetting(PrimaryModel):  # pylint: disable=too-many-ancestors
         on_delete=models.PROTECT,
         related_name="golden_config_setting",
     )
+    is_dynamic_group_associable_model = False
 
     objects = GoldenConfigSettingManager()
 


### PR DESCRIPTION
Closes #835 

This resolves the issue when trying to open the Golden Config Settings page. It is related to https://github.com/nautobot/nautobot/issues/6582.

The issue is that this model has both a OneToOne field with Dynamic Groups and a ManyToMany with Dynamic Groups. This pr makes the Golden Config Settings not be associated with Dynamic Groups to remove the ManyToMany relationship with Dynamic Groups.