### PR TITLE
Fixed failing tests in Nautobot v2.3.13

### DIFF
--- a/changes/849.fixed
+++ b/changes/849.fixed
@@ -1,0 +1,1 @@
+Fixed failing tests in Nautobot v2.3.13.

--- a/nautobot_golden_config/tests/test_api.py
+++ b/nautobot_golden_config/tests/test_api.py
@@ -6,13 +6,13 @@ from unittest.mock import patch
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
-from nautobot.core.testing import APITestCase, APIViewTestCases
+from nautobot.apps.testing import APITestCase, APIViewTestCases
 from nautobot.dcim.models import Device, Platform
 from nautobot.extras.models import DynamicGroup, GitRepository, GraphQLQuery, Status
 from rest_framework import status
 
 from nautobot_golden_config.choices import RemediationTypeChoice
-from nautobot_golden_config.models import ConfigPlan, GoldenConfigSetting, RemediationSetting
+from nautobot_golden_config.models import ConfigPlan, ConfigReplace, GoldenConfigSetting, RemediationSetting
 from nautobot_golden_config.tests.conftest import (
     create_config_compliance,
     create_device,
@@ -406,6 +406,63 @@ class ConfigPlanTest(
             "change_control_id": "Test Change Control ID 5",
             "change_control_url": "https://5.example.com/",
             "status": approved_status.pk,
+        }
+
+
+class ConfigReplaceAPITestCase(
+    APIViewTestCases.CreateObjectViewTestCase,
+    APIViewTestCases.GetObjectViewTestCase,
+    APIViewTestCases.ListObjectsViewTestCase,
+    APIViewTestCases.UpdateObjectViewTestCase,
+    APIViewTestCases.DeleteObjectViewTestCase,
+    APIViewTestCases.NotesURLViewTestCase,
+):
+    model = ConfigReplace
+
+    @classmethod
+    def setUpTestData(cls):
+        create_device_data()
+        platform = Device.objects.first().platform
+        for i in range(3):
+            ConfigReplace.objects.create(
+                name=f"test configreplace {i}",
+                platform=platform,
+                description="test description",
+                regex="^(.*)$",
+                replace="xyz",
+            )
+        cls.update_data = {
+            "name": "new name",
+            "platform": platform.pk,
+            "description": "new description",
+            "regex": "^NEW (.*)$",
+            "replace": "NEW replaced text",
+        }
+        cls.create_data = [
+            {
+                "name": "test configreplace 4",
+                "platform": platform.pk,
+                "description": "test description",
+                "regex": "^(.*)$",
+                "replace": "xyz",
+            },
+            {
+                "name": "test configreplace 5",
+                "platform": platform.pk,
+                "description": "test description",
+                "regex": "^(.*)$",
+                "replace": "xyz",
+            },
+            {
+                "name": "test configreplace 6",
+                "platform": platform.pk,
+                "description": "test description",
+                "regex": "^(.*)$",
+                "replace": "xyz",
+            },
+        ]
+        cls.bulk_update_data = {
+            "description": "new description",
         }
 
 

--- a/nautobot_golden_config/tests/test_api.py
+++ b/nautobot_golden_config/tests/test_api.py
@@ -409,7 +409,7 @@ class ConfigPlanTest(
         }
 
 
-class ConfigReplaceAPITestCase(
+class ConfigReplaceAPITestCase(  # pylint: disable=too-many-ancestors
     APIViewTestCases.CreateObjectViewTestCase,
     APIViewTestCases.GetObjectViewTestCase,
     APIViewTestCases.ListObjectsViewTestCase,
@@ -417,15 +417,17 @@ class ConfigReplaceAPITestCase(
     APIViewTestCases.DeleteObjectViewTestCase,
     APIViewTestCases.NotesURLViewTestCase,
 ):
+    """Test API for ConfigReplace."""
+
     model = ConfigReplace
 
     @classmethod
     def setUpTestData(cls):
         create_device_data()
         platform = Device.objects.first().platform
-        for i in range(3):
+        for num in range(3):
             ConfigReplace.objects.create(
-                name=f"test configreplace {i}",
+                name=f"test configreplace {num}",
                 platform=platform,
                 description="test description",
                 regex="^(.*)$",

--- a/nautobot_golden_config/tests/test_views.py
+++ b/nautobot_golden_config/tests/test_views.py
@@ -132,6 +132,14 @@ class ConfigReplaceUIViewSetTestCase(ViewTestCases.PrimaryObjectViewTestCase):  
             "replace": "NEW replaced text",
         }
 
+        # For compatibility with Nautobot lower than v2.2.0
+        cls.csv_data = (
+            "name,regex,replace,platform",
+            f"test configreplace 4,^(.*)$,xyz,{platform.pk}",
+            f"test configreplace 5,^(.*)$,xyz,{platform.pk}",
+            f"test configreplace 6,^(.*)$,xyz,{platform.pk}",
+        )
+
 
 class GoldenConfigListViewTestCase(TestCase):
     """Test GoldenConfigListView."""

--- a/nautobot_golden_config/tests/test_views.py
+++ b/nautobot_golden_config/tests/test_views.py
@@ -102,8 +102,8 @@ class ConfigComplianceOverviewHelperTestCase(TestCase):
         mock_graph_ql_query.assert_called()
 
 
-class ConfigReplaceUIViewSetTestCase(ViewTestCases.PrimaryObjectViewTestCase):
-    """Test ConfigReplaceListView."""
+class ConfigReplaceUIViewSetTestCase(ViewTestCases.PrimaryObjectViewTestCase):  # pylint: disable=too-many-ancestors
+    """Test ConfigReplaceUIViewSet."""
 
     model = models.ConfigReplace
 
@@ -116,9 +116,9 @@ class ConfigReplaceUIViewSetTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         """Set up base objects."""
         create_device_data()
         platform = Device.objects.first().platform
-        for i in range(3):
+        for num in range(3):
             models.ConfigReplace.objects.create(
-                name=f"test configreplace {i}",
+                name=f"test configreplace {num}",
                 platform=platform,
                 description="test description",
                 regex="^(.*)$",


### PR DESCRIPTION
This removes the bespoke test in test_views.py that was testing for csv export/import roundtrip compatibility and replaced it with generic nautobot view tests. Also added generic nautobot api view tests for this model that includes a test for this specific purpose:

```
test_recreate_object_csv (nautobot_golden_config.tests.test_api.ConfigReplaceAPITestCase.test_recreate_object_csv)
CSV export an object, delete it, and recreate it via CSV import. ... ok
```