### PR TITLE
Set max-height on Device Config Compliance tab configs

### DIFF
--- a/changes/850.changed
+++ b/changes/850.changed
@@ -1,0 +1,1 @@
+Changed the way that actual and intended configs are rendered within the text box to have a scroll bar.

--- a/nautobot_golden_config/templates/nautobot_golden_config/configcompliance_devicetab.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/configcompliance_devicetab.html
@@ -20,7 +20,13 @@
         min-width: 200px;
         width: 100%;
         padding: 15px;
-        height:max-content;
+        height: max-content;
+    }
+    #compliance-content td.config_hover span[id*="_intended"] pre {
+        max-height: 300px;
+    }
+    #compliance-content td.config_hover span[id*="_actual"] pre {
+        max-height: 300px;
     }
     #navigation span.config_hover_button {
         vertical-align: center;


### PR DESCRIPTION
Minor CSS update to limit the display size of large configurations in the Device Config Compliance tab. Details in issue #860 

Maintainer Note here is the screenshot:

![image](https://github.com/user-attachments/assets/9eed4100-2318-4668-9156-5608f5a58717)
