### PR TITLE
Fixed copy button not hidden on diff tab in generate intended config tool

### DIFF
--- a/changes/887.fixed
+++ b/changes/887.fixed
@@ -1,0 +1,1 @@
+Fixed copy button not hidden on diff tab in generate intended config tool.

--- a/nautobot_golden_config/templates/nautobot_golden_config/generate_intended_config.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/generate_intended_config.html
@@ -326,5 +326,15 @@
                 rendered_config_code_block.innerHTML = sanitize(`An error occurred:\n\n${error.message}`);
             }
         }
+
+        // Hide the copy button when the diff tab is active
+        const copyButton = document.querySelector(".copy-rendered-config");
+        $('[href="#id_diff_tab_content"]').on('shown.bs.tab', function (e) {
+            copyButton.style.display = "none";
+        });
+        $('[href="#id_diff_tab_content"]').on('hidden.bs.tab', function (e) {
+            copyButton.style.display = "inline-block";
+        });
+
     </script>
 {% endblock javascript %}


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to Golden Config! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #887

## What's Changed

This hides the copy button when the diff tab is active
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
