### PR TITLE
Remove conditional UI views

### DIFF
--- a/changes/914.changed
+++ b/changes/914.changed
@@ -1,0 +1,1 @@
+Removes conditional UI views for when compliance, intended, and backup settings are disabled.

--- a/nautobot_golden_config/navigation.py
+++ b/nautobot_golden_config/navigation.py
@@ -2,129 +2,91 @@
 
 from nautobot.apps.ui import NavMenuAddButton, NavMenuGroup, NavMenuItem, NavMenuTab
 
-from nautobot_golden_config.utilities.constant import ENABLE_BACKUP, ENABLE_COMPLIANCE, ENABLE_PLAN
-
-items_operate = [
+items_operate = (
     NavMenuItem(
         link="plugins:nautobot_golden_config:goldenconfig_list",
         name="Config Overview",
         permissions=["nautobot_golden_config.view_goldenconfig"],
-    )
-]
-
-items_setup = []
-
-if ENABLE_COMPLIANCE:
-    items_operate.append(
-        NavMenuItem(
-            link="plugins:nautobot_golden_config:configcompliance_list",
-            name="Config Compliance",
-            permissions=["nautobot_golden_config.view_configcompliance"],
-        )
-    )
-
-if ENABLE_COMPLIANCE:
-    items_setup.append(
-        NavMenuItem(
-            link="plugins:nautobot_golden_config:compliancerule_list",
-            name="Compliance Rules",
-            permissions=["nautobot_golden_config.view_compliancerule"],
-            buttons=(
-                NavMenuAddButton(
-                    link="plugins:nautobot_golden_config:compliancerule_add",
-                    permissions=["nautobot_golden_config.add_compliancerule"],
-                ),
+    ),
+    NavMenuItem(
+        link="plugins:nautobot_golden_config:configcompliance_list",
+        name="Config Compliance",
+        permissions=["nautobot_golden_config.view_configcompliance"],
+    ),
+    NavMenuItem(
+        link="plugins:nautobot_golden_config:configcompliance_overview",
+        name="Compliance Report",
+        permissions=["nautobot_golden_config.view_configcompliance"],
+    ),
+    NavMenuItem(
+        link="plugins:nautobot_golden_config:configplan_list",
+        name="Config Plans",
+        permissions=["nautobot_golden_config.view_configplan"],
+        buttons=(
+            NavMenuAddButton(
+                link="plugins:nautobot_golden_config:configplan_add",
+                permissions=["nautobot_golden_config.add_configplan"],
             ),
-        )
-    )
+        ),
+    ),
+)
 
-if ENABLE_COMPLIANCE:
-    items_setup.append(
-        NavMenuItem(
-            link="plugins:nautobot_golden_config:compliancefeature_list",
-            name="Compliance Features",
-            permissions=["nautobot_golden_config.view_compliancefeature"],
-            buttons=(
-                NavMenuAddButton(
-                    link="plugins:nautobot_golden_config:compliancefeature_add",
-                    permissions=["nautobot_golden_config.add_compliancefeature"],
-                ),
+items_setup = (
+    NavMenuItem(
+        link="plugins:nautobot_golden_config:compliancerule_list",
+        name="Compliance Rules",
+        permissions=["nautobot_golden_config.view_compliancerule"],
+        buttons=(
+            NavMenuAddButton(
+                link="plugins:nautobot_golden_config:compliancerule_add",
+                permissions=["nautobot_golden_config.add_compliancerule"],
             ),
-        )
-    )
-
-
-if ENABLE_COMPLIANCE:
-    items_operate.append(
-        NavMenuItem(
-            link="plugins:nautobot_golden_config:configcompliance_overview",
-            name="Compliance Report",
-            permissions=["nautobot_golden_config.view_configcompliance"],
-        )
-    )
-
-if ENABLE_PLAN:
-    items_operate.append(
-        NavMenuItem(
-            link="plugins:nautobot_golden_config:configplan_list",
-            name="Config Plans",
-            permissions=["nautobot_golden_config.view_configplan"],
-            buttons=(
-                NavMenuAddButton(
-                    link="plugins:nautobot_golden_config:configplan_add",
-                    permissions=["nautobot_golden_config.add_configplan"],
-                ),
+        ),
+    ),
+    NavMenuItem(
+        link="plugins:nautobot_golden_config:compliancefeature_list",
+        name="Compliance Features",
+        permissions=["nautobot_golden_config.view_compliancefeature"],
+        buttons=(
+            NavMenuAddButton(
+                link="plugins:nautobot_golden_config:compliancefeature_add",
+                permissions=["nautobot_golden_config.add_compliancefeature"],
             ),
-        )
-    )
-
-if ENABLE_BACKUP:
-    items_setup.append(
-        NavMenuItem(
-            link="plugins:nautobot_golden_config:configremove_list",
-            name="Config Removals",
-            permissions=["nautobot_golden_config.view_configremove"],
-            buttons=(
-                NavMenuAddButton(
-                    link="plugins:nautobot_golden_config:configremove_add",
-                    permissions=["nautobot_golden_config.add_configremove"],
-                ),
+        ),
+    ),
+    NavMenuItem(
+        link="plugins:nautobot_golden_config:configremove_list",
+        name="Config Removals",
+        permissions=["nautobot_golden_config.view_configremove"],
+        buttons=(
+            NavMenuAddButton(
+                link="plugins:nautobot_golden_config:configremove_add",
+                permissions=["nautobot_golden_config.add_configremove"],
             ),
-        )
-    )
-
-if ENABLE_BACKUP:
-    items_setup.append(
-        NavMenuItem(
-            link="plugins:nautobot_golden_config:configreplace_list",
-            name="Config Replacements",
-            permissions=["nautobot_golden_config.view_configreplace"],
-            buttons=(
-                NavMenuAddButton(
-                    link="plugins:nautobot_golden_config:configreplace_add",
-                    permissions=["nautobot_golden_config.add_configreplace"],
-                ),
+        ),
+    ),
+    NavMenuItem(
+        link="plugins:nautobot_golden_config:configreplace_list",
+        name="Config Replacements",
+        permissions=["nautobot_golden_config.view_configreplace"],
+        buttons=(
+            NavMenuAddButton(
+                link="plugins:nautobot_golden_config:configreplace_add",
+                permissions=["nautobot_golden_config.add_configreplace"],
             ),
-        )
-    )
-
-
-if ENABLE_COMPLIANCE:
-    items_setup.append(
-        NavMenuItem(
-            link="plugins:nautobot_golden_config:remediationsetting_list",
-            name="Remediation Settings",
-            permissions=["nautobot_golden_config.view_remediationsetting"],
-            buttons=(
-                NavMenuAddButton(
-                    link="plugins:nautobot_golden_config:remediationsetting_add",
-                    permissions=["nautobot_golden_config.add_remediationsetting"],
-                ),
+        ),
+    ),
+    NavMenuItem(
+        link="plugins:nautobot_golden_config:remediationsetting_list",
+        name="Remediation Settings",
+        permissions=["nautobot_golden_config.view_remediationsetting"],
+        buttons=(
+            NavMenuAddButton(
+                link="plugins:nautobot_golden_config:remediationsetting_add",
+                permissions=["nautobot_golden_config.add_remediationsetting"],
             ),
-        )
-    )
-
-items_setup.append(
+        ),
+    ),
     NavMenuItem(
         link="plugins:nautobot_golden_config:goldenconfigsetting_list",
         name="Golden Config Settings",
@@ -138,14 +100,13 @@ items_setup.append(
     ),
 )
 
-
 menu_items = (
     NavMenuTab(
         name="Golden Config",
         weight=1000,
         groups=(
-            NavMenuGroup(name="Manage", weight=100, items=tuple(items_operate)),
-            NavMenuGroup(name="Setup", weight=100, items=tuple(items_setup)),
+            NavMenuGroup(name="Manage", weight=100, items=items_operate),
+            NavMenuGroup(name="Setup", weight=100, items=items_setup),
             NavMenuGroup(
                 name="Tools",
                 weight=300,

--- a/nautobot_golden_config/templates/nautobot_golden_config/configcompliance_list.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/configcompliance_list.html
@@ -7,9 +7,7 @@
         <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Execute <span class="caret"></span>
     </button>
     <ul class="dropdown-menu">
-        {% if compliance %}
-            <li><a href="{% url 'extras:job_run_by_class_path' class_path='nautobot_golden_config.jobs.ComplianceJob' %}">Compliance</a></li>
-        {% endif %}
+        <li><a href="{% url 'extras:job_run_by_class_path' class_path='nautobot_golden_config.jobs.ComplianceJob' %}">Compliance</a></li>
     </ul>
 </div>
 {% endblock %}

--- a/nautobot_golden_config/templates/nautobot_golden_config/configcompliance_overview.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/configcompliance_overview.html
@@ -16,9 +16,7 @@
         <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Execute <span class="caret"></span>
     </button>
     <ul class="dropdown-menu">
-        {% if compliance %}
-            <li><a href="{% url 'extras:job_run_by_class_path' class_path='nautobot_golden_config.jobs.ComplianceJob' %}">Compliance</a></li>
-        {% endif %}
+        <li><a href="{% url 'extras:job_run_by_class_path' class_path='nautobot_golden_config.jobs.ComplianceJob' %}">Compliance</a></li>
     </ul>
 </div>
 {% endblock %}

--- a/nautobot_golden_config/templates/nautobot_golden_config/content_template.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/content_template.html
@@ -1,4 +1,3 @@
-{% if compliance %}
   <div class="panel panel-default">
     {% if template_type == "devicetab" %}
       <div class="panel-heading">
@@ -51,7 +50,6 @@
       </table>
     {% endif %}
   </div>
-{% endif %}
 {# The panel will not show up, since it is returned early in template_content.py based on an actual GoldenConfig object existing #}
 {% if template_type == "device-configs" %}
   <div class="panel panel-default">

--- a/nautobot_golden_config/templates/nautobot_golden_config/goldenconfig_list.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/goldenconfig_list.html
@@ -37,18 +37,10 @@
         <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Execute <span class="caret"></span>
     </button>
     <ul class="dropdown-menu">
-        {% if compliance %}
-            <li><a href="{% url 'extras:job_run_by_class_path' class_path='nautobot_golden_config.jobs.ComplianceJob' %}">Compliance</a></li>
-        {% endif %}
-        {% if intended %}
-            <li><a href="{% url 'extras:job_run_by_class_path' class_path='nautobot_golden_config.jobs.IntendedJob' %}">Intended</a></li>
-        {% endif %}
-        {% if backup %}
-            <li><a href="{% url 'extras:job_run_by_class_path' class_path='nautobot_golden_config.jobs.BackupJob' %}">Backup</a></li>
-        {% endif %}
-        {% if not compliance and not intended and not backup %}
-            <li><a href="#" class="disabled">Features are not enabled.</a></li>
-        {% endif %}
+        <li><a href="{% url 'extras:job_run_by_class_path' class_path='nautobot_golden_config.jobs.ComplianceJob' %}">Compliance</a></li>
+        <li><a href="{% url 'extras:job_run_by_class_path' class_path='nautobot_golden_config.jobs.IntendedJob' %}">Intended</a></li>
+        <li><a href="{% url 'extras:job_run_by_class_path' class_path='nautobot_golden_config.jobs.BackupJob' %}">Backup</a></li>
+        <li><a href="#" class="disabled">Features are not enabled.</a></li>
     </ul>
 </div>
 {% endblock %}


### PR DESCRIPTION
## What's Changed

Addresses the requirement of #842 to remove conditional UI views when compliance, intended, or backup settings are enabled / disabled.

These items can be hidden from the UI with saved UI views. However, there are scenarios where displaying that information is necessary, even if the setting is disabled. For example, we have a job that backs up devices through a separate process and updates the backup timestamps in the ORM. Since the built-in golden config setting is disabled, the ability to see the last time backups were run is unavailable by default. This adjustment ensures that view is still accessible.

## To Do

- [x] Explanation of Change(s)


