### PR TITLE
Changing the settings form to use dynamic dropdowns

### DIFF
--- a/changes/+dynamic-form.changed
+++ b/changes/+dynamic-form.changed
@@ -1,0 +1,1 @@
+Changed the Golden Config Setting form to use dynamic dropdowns for the related models.

--- a/nautobot_golden_config/forms.py
+++ b/nautobot_golden_config/forms.py
@@ -345,13 +345,23 @@ class ConfigReplaceBulkEditForm(NautobotBulkEditForm):
 
 
 class GoldenConfigSettingForm(NautobotModelForm):
-    """Filter Form for GoldenConfigSettingForm instances."""
+    """Form for GoldenConfigSetting instances."""
 
     slug = forms.SlugField()
-    dynamic_group = django_forms.ModelChoiceField(queryset=DynamicGroup.objects.all())
+    dynamic_group = forms.DynamicModelChoiceField(queryset=DynamicGroup.objects.all())
+    backup_repository = forms.DynamicModelChoiceField(
+        queryset=GitRepository.objects.filter(provided_contents__contains="nautobot_golden_config.backupconfigs")
+    )
+    intended_repository = forms.DynamicModelChoiceField(
+        queryset=GitRepository.objects.filter(provided_contents__contains="nautobot_golden_config.intendedconfigs")
+    )
+    jinja_repository = forms.DynamicModelChoiceField(
+        queryset=GitRepository.objects.filter(provided_contents__contains="nautobot_golden_config.jinjatemplate")
+    )
+    sot_agg_query = forms.DynamicModelChoiceField(queryset=GraphQLQuery.objects.all())
 
     class Meta:
-        """Filter Form Meta Data for GoldenConfigSettingForm instances."""
+        """Form Meta Data for GoldenConfigSetting instances."""
 
         model = models.GoldenConfigSetting
         fields = "__all__"

--- a/nautobot_golden_config/forms.py
+++ b/nautobot_golden_config/forms.py
@@ -348,17 +348,21 @@ class GoldenConfigSettingForm(NautobotModelForm):
     """Form for GoldenConfigSetting instances."""
 
     slug = forms.SlugField()
+    # Should filter model and this by dynamic groups of content type devices
     dynamic_group = forms.DynamicModelChoiceField(queryset=DynamicGroup.objects.all())
     backup_repository = forms.DynamicModelChoiceField(
-        queryset=GitRepository.objects.filter(provided_contents__contains="nautobot_golden_config.backupconfigs"),
+        queryset=GitRepository.objects.all(),
+        query_params={"provided_contents": "nautobot_golden_config.backupconfigs"},
         required=False,
     )
     intended_repository = forms.DynamicModelChoiceField(
-        queryset=GitRepository.objects.filter(provided_contents__contains="nautobot_golden_config.intendedconfigs"),
+        queryset=GitRepository.objects.all(),
+        query_params={"provided_contents": "nautobot_golden_config.intendedconfigs"},
         required=False,
     )
     jinja_repository = forms.DynamicModelChoiceField(
-        queryset=GitRepository.objects.filter(provided_contents__contains="nautobot_golden_config.jinjatemplate"),
+        queryset=GitRepository.objects.all(),
+        query_params={"provided_contents": "nautobot_golden_config.jinjatemplate"},
         required=False,
     )
     sot_agg_query = forms.DynamicModelChoiceField(queryset=GraphQLQuery.objects.all(), required=False)

--- a/nautobot_golden_config/forms.py
+++ b/nautobot_golden_config/forms.py
@@ -350,15 +350,18 @@ class GoldenConfigSettingForm(NautobotModelForm):
     slug = forms.SlugField()
     dynamic_group = forms.DynamicModelChoiceField(queryset=DynamicGroup.objects.all())
     backup_repository = forms.DynamicModelChoiceField(
-        queryset=GitRepository.objects.filter(provided_contents__contains="nautobot_golden_config.backupconfigs")
+        queryset=GitRepository.objects.filter(provided_contents__contains="nautobot_golden_config.backupconfigs"),
+        required=False,
     )
     intended_repository = forms.DynamicModelChoiceField(
-        queryset=GitRepository.objects.filter(provided_contents__contains="nautobot_golden_config.intendedconfigs")
+        queryset=GitRepository.objects.filter(provided_contents__contains="nautobot_golden_config.intendedconfigs"),
+        required=False,
     )
     jinja_repository = forms.DynamicModelChoiceField(
-        queryset=GitRepository.objects.filter(provided_contents__contains="nautobot_golden_config.jinjatemplate")
+        queryset=GitRepository.objects.filter(provided_contents__contains="nautobot_golden_config.jinjatemplate"),
+        required=False,
     )
-    sot_agg_query = forms.DynamicModelChoiceField(queryset=GraphQLQuery.objects.all())
+    sot_agg_query = forms.DynamicModelChoiceField(queryset=GraphQLQuery.objects.all(), required=False)
 
     class Meta:
         """Form Meta Data for GoldenConfigSetting instances."""


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Golden Config! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #DNE

## What's Changed
This is just a QOL PR that changes the dropdown options on the settings form to use dynamic selections instead of static. I have found that when I set up a new instance of GC I don't always create the necessary git repo(s) and GQL query before trying to edit the default settings, so I go and create them in another tab and come back. But, the current selection boxes are static so I have to reload the page and start over.

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
