### PR TITLE
Fix config compliance anchor scroll

### DIFF
--- a/changes/896.fixed
+++ b/changes/896.fixed
@@ -1,0 +1,1 @@
+Fixed an issue where the Configuration Compliance Feature Navigation did not scroll to the correct section on first click or page load.

--- a/nautobot_golden_config/static/anchor_scroll.js
+++ b/nautobot_golden_config/static/anchor_scroll.js
@@ -1,0 +1,26 @@
+document.addEventListener("DOMContentLoaded", function () {
+    // Intercept anchor clicks and delay scroll to ensure layout is ready
+    document.querySelectorAll('a[href^="#"]').forEach(function (link) {
+        link.addEventListener("click", function (e) {
+            e.preventDefault();
+            var id = this.getAttribute("href").substring(1);
+            var target = document.getElementById(id);
+            if (target) {
+                setTimeout(() => {
+                    target.scrollIntoView({ behavior: "smooth" });
+                }, 100); // delay ensures target is in correct position
+            }
+        });
+    });
+
+    // Handle scroll when page loads with a hash in the URL
+    if (window.location.hash) {
+        var id = window.location.hash.substring(1);
+        var target = document.getElementById(id);
+        if (target) {
+            setTimeout(() => {
+                target.scrollIntoView({ behavior: "smooth" });
+            }, 100); // same delay applies here
+        }
+    }
+});

--- a/nautobot_golden_config/templates/nautobot_golden_config/configcompliance_devicetab.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/configcompliance_devicetab.html
@@ -5,6 +5,11 @@
 
 {% block title %} {{ object }} - Config Compliance {% endblock %}
 
+{% block javascript %}
+{{ block.super }}
+<script src="{% static 'anchor_scroll.js' %}"></script>
+{% endblock %}
+
 {% block extra_styles %}
 {{ block.super }}
 <style>


### PR DESCRIPTION
# Closes: nautobot/nautobot#7328 

## What's Changed

<!--
- Fixed an issue where the Configuration Compliance Feature Navigation did not scroll to the correct section on first click or page load.
-->
