### PR TITLE
Verify no other object has same time before changing it

### DIFF
--- a/nautobot_golden_config/migrations/0029_alter_configplan_unique_together.py
+++ b/nautobot_golden_config/migrations/0029_alter_configplan_unique_together.py
@@ -24,7 +24,16 @@ def ensure_config_plan_created_timestamps_are_unique(apps, schema_editor):
     for duplicate_record in duplicate_records:
         duplicate_record.pop("count")
         for record in ConfigPlan.objects.filter(**duplicate_record):
-            record.created += timedelta(milliseconds=secrets.randbelow(1000))
+            new_time = record.created + timedelta(milliseconds=secrets.randbelow(1000))
+
+            while (
+                ConfigPlan.objects.filter(plan_type=record.plan_type, device=record.device, created=new_time).length()
+                > 0
+            ):
+                # Make sure there are no other lines conflicting with the new time
+                new_time = record.created + timedelta(milliseconds=secrets.randbelow(1000))
+
+            record.created = new_time
             record.save()
 
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Golden Config! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #951 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

Migration 0029 adds random milliseconds to the timestamp of lines that would conflict with the new index so they are no longer unique.

I have observed migrations fail randomly because either the function is adding the same number of milliseconds to more than one line, or because the new timestamp accidentally collides with another non-duplicate line.

My change checks whether the data we're about to update conflicts with pre-existing lines in the DB

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [X] Attached Screenshots, Payload Example
- [X] Unit, Integration Tests
- [] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
