### PR TITLE
Adding a fail option to config plan deployment job

### DIFF
--- a/changes/955.added
+++ b/changes/955.added
@@ -1,0 +1,1 @@
+Added an option to fail the Config Plan Deployment Job if any tasks for any device fails.

--- a/nautobot_golden_config/exceptions.py
+++ b/nautobot_golden_config/exceptions.py
@@ -27,3 +27,7 @@ class IntendedGenerationFailure(GoldenConfigError):
 
 class ComplianceFailure(GoldenConfigError):
     """Custom error for when there's a failure in Compliance Job."""
+
+
+class ConfigPlanDeploymentFailure(GoldenConfigError):
+    """Custom error for when there's a failure in Config Plan Deployment Job."""

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -529,6 +529,7 @@ class DeployConfigPlans(Job):
     """Job to deploy config plans."""
 
     config_plan = MultiObjectVar(model=ConfigPlan, required=True)
+    fail_job_on_task_failure = BooleanVar(description="If any tasks for any device fails, fail the entire job result.")
     debug = BooleanVar(description="Enable for more verbose debug logging")
 
     class Meta:
@@ -549,7 +550,13 @@ class DeployConfigPlans(Job):
         update_dynamic_groups_cache()
         self.logger.debug("Starting config plan deployment job.")
         self.data = data
-        config_deployment(self)
+        try:
+            config_deployment(self)
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            error_msg = f"`E3001:` General Exception handler, original error message ```{error}```"
+            self.logger.error(error_msg)
+            if data.get("fail_job_on_task_failure"):
+                raise NornirNautobotException(error_msg) from error
 
 
 class DeployConfigPlanJobButtonReceiver(JobButtonReceiver):

--- a/nautobot_golden_config/nornir_plays/config_deployment.py
+++ b/nautobot_golden_config/nornir_plays/config_deployment.py
@@ -16,6 +16,7 @@ from nornir.core.task import Result, Task
 from nornir_nautobot.exceptions import NornirNautobotException
 from nornir_nautobot.plugins.tasks.dispatcher import dispatcher
 
+from nautobot_golden_config.exceptions import ConfigPlanDeploymentFailure
 from nautobot_golden_config.nornir_plays.processor import ProcessGoldenConfig
 from nautobot_golden_config.utilities.config_postprocessing import get_config_postprocessing
 from nautobot_golden_config.utilities.constant import DEFAULT_DEPLOY_STATUS, ENABLE_POSTPROCESSING
@@ -115,7 +116,7 @@ def config_deployment(job):
         ) as nornir_obj:
             nr_with_processors = nornir_obj.with_processors([ProcessGoldenConfig(logger)])
 
-            nr_with_processors.run(
+            results = nr_with_processors.run(
                 task=run_deployment,
                 name="DEPLOY CONFIG",
                 logger=logger,
@@ -129,3 +130,5 @@ def config_deployment(job):
         raise NornirNautobotException(error_msg) from error
 
     logger.debug("Completed configuration deployment.")
+    if results.failed:
+        raise ConfigPlanDeploymentFailure()

--- a/nautobot_golden_config/tests/test_nornir_plays/test_config_deployment.py
+++ b/nautobot_golden_config/tests/test_nornir_plays/test_config_deployment.py
@@ -10,6 +10,7 @@ from nautobot.extras.models import JobResult, Status
 from nautobot_golden_config.exceptions import ConfigPlanDeploymentFailure
 from nautobot_golden_config.models import ConfigPlan
 from nautobot_golden_config.nornir_plays.config_deployment import config_deployment
+from nautobot_golden_config.tests.conftest import create_device
 
 
 class ConfigDeploymentTest(unittest.TestCase):
@@ -17,6 +18,7 @@ class ConfigDeploymentTest(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
+        create_device()
         self.device = Device.objects.first()
         self.plan_result = JobResult.objects.create(
             name="Test Plan Result",
@@ -29,11 +31,12 @@ class ConfigDeploymentTest(unittest.TestCase):
             status=Status.objects.get(name="Approved"),
             plan_result=self.plan_result,
         )
+        self.user, _ = get_user_model().objects.get_or_create(username="testuser")
 
         # Create mock job
         self.job = MagicMock()
         self.job.data = {"config_plan": ConfigPlan.objects.all()}
-        self.job.celery_kwargs = {"nautobot_job_user_id": get_user_model().objects.first().id}
+        self.job.celery_kwargs = {"nautobot_job_user_id": self.user.id}
         self.job.job_result = Mock()
         self.job.logger.getEffectiveLevel = Mock(return_value=0)
 

--- a/nautobot_golden_config/tests/test_nornir_plays/test_config_deployment.py
+++ b/nautobot_golden_config/tests/test_nornir_plays/test_config_deployment.py
@@ -4,12 +4,12 @@ import unittest
 from unittest.mock import MagicMock, Mock, patch
 
 from django.contrib.auth import get_user_model
-
-from nautobot_golden_config.nornir_plays.config_deployment import config_deployment
-from nautobot_golden_config.models import ConfigPlan
-from nautobot_golden_config.exceptions import ConfigPlanDeploymentFailure
 from nautobot.dcim.models import Device
-from nautobot.extras.models import Status, JobResult
+from nautobot.extras.models import JobResult, Status
+
+from nautobot_golden_config.exceptions import ConfigPlanDeploymentFailure
+from nautobot_golden_config.models import ConfigPlan
+from nautobot_golden_config.nornir_plays.config_deployment import config_deployment
 
 
 class ConfigDeploymentTest(unittest.TestCase):

--- a/nautobot_golden_config/tests/test_nornir_plays/test_config_deployment.py
+++ b/nautobot_golden_config/tests/test_nornir_plays/test_config_deployment.py
@@ -1,0 +1,89 @@
+"""Unit tests for config_deployment.py."""
+
+import unittest
+from unittest.mock import MagicMock, Mock, patch
+
+from django.contrib.auth import get_user_model
+
+from nautobot_golden_config.nornir_plays.config_deployment import config_deployment
+from nautobot_golden_config.models import ConfigPlan
+from nautobot_golden_config.exceptions import ConfigPlanDeploymentFailure
+from nautobot.dcim.models import Device
+from nautobot.extras.models import Status, JobResult
+
+
+class ConfigDeploymentTest(unittest.TestCase):
+    """Unit tests for config_deployment.py."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.device = Device.objects.first()
+        self.plan_result = JobResult.objects.create(
+            name="Test Plan Result",
+            status=Status.objects.get(name="Completed"),
+        )
+        self.config_plan = ConfigPlan.objects.create(
+            plan_type="manual",
+            device=self.device,
+            config_set="Test Config Set",
+            status=Status.objects.get(name="Approved"),
+            plan_result=self.plan_result,
+        )
+
+        # Create mock job
+        self.job = MagicMock()
+        self.job.data = {"config_plan": ConfigPlan.objects.all()}
+        self.job.celery_kwargs = {"nautobot_job_user_id": get_user_model().objects.first().id}
+        self.job.job_result = Mock()
+        self.job.logger.getEffectiveLevel = Mock(return_value=0)
+
+    @patch("nautobot_golden_config.nornir_plays.config_deployment.InitNornir")
+    def test_config_deployment_success(self, mock_nornir):
+        """Test successful config deployment."""
+        # Mock the nornir run results
+        mock_host = Mock()
+        mock_host.name = self.device.name
+        mock_result = Mock()
+        mock_result.failed = False
+        mock_result.changed = True
+        mock_results = Mock()
+        mock_results.failed = False
+
+        # Set up the mock nornir object and run method
+        mock_nr = Mock()
+        mock_nr.with_processors.return_value = mock_nr
+        mock_nr.run.return_value = mock_results
+        mock_nornir.return_value.__enter__.return_value = mock_nr
+
+        # Run the deployment
+        config_deployment(self.job)
+
+        # Verify nornir was called
+        mock_nornir.assert_called_once()
+        mock_nr.run.assert_called_once()
+
+    @patch("nautobot_golden_config.nornir_plays.config_deployment.InitNornir")
+    def test_config_deployment_failure(self, mock_nornir):
+        """Test failed config deployment raises ConfigPlanDeploymentFailure."""
+        # Mock the nornir run results for failure scenario
+        mock_host = Mock()
+        mock_host.name = self.device.name
+        mock_result = Mock()
+        mock_result.failed = True
+        mock_result.changed = False
+        mock_results = Mock()
+        mock_results.failed = True
+
+        # Set up the mock nornir object and run method
+        mock_nr = Mock()
+        mock_nr.with_processors.return_value = mock_nr
+        mock_nr.run.return_value = mock_results
+        mock_nornir.return_value.__enter__.return_value = mock_nr
+
+        # Run the deployment and expect ConfigPlanDeploymentFailure
+        with self.assertRaises(ConfigPlanDeploymentFailure):
+            config_deployment(self.job)
+
+        # Verify nornir was called
+        mock_nornir.assert_called_once()
+        mock_nr.run.assert_called_once()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Golden Config! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #955

## What's Changed
This PR adds the same logic that the other nornir tasks do to raise an error if any of the sub-tasks fails. I also added in the option to the deployment job to fail the job if any task fails so that it mimics the others as well.
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
