### PR TITLE
Add GC versions 2.4.x and 2.5.x to the Compatibility Matrix

### DIFF
--- a/changes/995.fixed
+++ b/changes/995.fixed
@@ -1,0 +1,1 @@
+Fixed Compatibility Matrix by adding versions 2.4.x and 2.5.x.

--- a/docs/admin/compatibility_matrix.md
+++ b/docs/admin/compatibility_matrix.md
@@ -21,3 +21,5 @@ While that last supported version will not be strictly enforced via the `max_ver
 | 2.1.x                 | 2.0.0                          | 2.3.99 [Official]             |
 | 2.2.x                 | 2.0.0                          | 2.3.99 [Official]             |
 | 2.3.x                 | 2.4.2                          | 2.4.99                        |
+| 2.4.x                 | 2.4.2                          | 2.4.99                        |
+| 2.5.x                 | 2.4.2                          | 2.4.99                        |


### PR DESCRIPTION
# Closes: #995 

## What's Changed
Adds GC versions 2.4.x and 2.5.x to the Compatibility Matrix.

Before
<img width="744" height="545" alt="image" src="https://github.com/user-attachments/assets/4c7455a6-f9fc-40ba-a812-caa67d1804bd" />

After
<img width="744" height="615" alt="image" src="https://github.com/user-attachments/assets/e3708d79-c356-4a18-8207-22c37ca918fa" />



## To Do
- [X] Explanation of Change(s)
- [X] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [X] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [X] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
