### PR TITLE
Allow 1 tree query for ConflgPlan

### DIFF
--- a/changes/1008.fixed
+++ b/changes/1008.fixed
@@ -1,0 +1,1 @@
+Fixed Unittest failure for ConfigPlan allowed_number_of_tree_queries_per_view_type.

--- a/nautobot_golden_config/tests/test_views.py
+++ b/nautobot_golden_config/tests/test_views.py
@@ -269,6 +269,9 @@ class ConfigPlanTestCase(
     """Test ConfigPlan views."""
 
     model = models.ConfigPlan
+    allowed_number_of_tree_queries_per_view_type = {
+        "retrieve": 1,
+    }
 
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Golden Config! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #NAPPS-580

Fixes Unittest error:
```
AssertionError: 1 != 0 : This view was expected to execute 0 recursive database queries but 1 were executed. If this is expected, please update the ConfigPlanTestCase.allowed_number_of_tree_queries_per_view_type['retrieve'] property. Care should be taken to only increase these numbers where necessary - recursive queries can become really slow with bigger datasets. The following queries were used:
```

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
