### PR TITLE
release v2.6.0

### DIFF
--- a/changes/+nautobot-app-v2.7.0.housekeeping
+++ b/changes/+nautobot-app-v2.7.0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.0`.

--- a/changes/+nautobot-app-v2.7.1.housekeeping
+++ b/changes/+nautobot-app-v2.7.1.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.1`.

--- a/changes/+nautobot-app-v2.7.2.housekeeping
+++ b/changes/+nautobot-app-v2.7.2.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.2`.

--- a/changes/1008.fixed
+++ b/changes/1008.fixed
@@ -1,1 +1,0 @@
-Fixed Unittest failure for ConfigPlan allowed_number_of_tree_queries_per_view_type.

--- a/changes/1022.housekeeping
+++ b/changes/1022.housekeeping
@@ -1,1 +1,0 @@
-Update any call to `get_extra_context` to call super of the method first.

--- a/docs/admin/release_notes/version_2.6.md
+++ b/docs/admin/release_notes/version_2.6.md
@@ -1,0 +1,19 @@
+# v2.6 Release Notes
+
+This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release Overview
+
+- Changed minimum Nautobot version to 2.4.20.
+- Dropped support for Python 3.9.
+
+<!-- towncrier release notes start -->
+## [v2.6.0 (2025-12-05)](https://github.com/nautobot/nautobot-app-golden-config/releases/tag/v2.6.0)
+
+### Housekeeping
+
+- [#1008](https://github.com/nautobot/nautobot-app-golden-config/issues/1008) - Fixed Unittest failure for ConfigPlan allowed_number_of_tree_queries_per_view_type.
+- [#1022](https://github.com/nautobot/nautobot-app-golden-config/issues/1022) - Update any call to `get_extra_context` to call super of the method first.
+- Rebaked from the cookie `nautobot-app-v2.7.0`.
+- Rebaked from the cookie `nautobot-app-v2.7.1`.
+- Rebaked from the cookie `nautobot-app-v2.7.2`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -169,6 +169,7 @@ nav:
       - Migrating To v2: "admin/migrating_to_v2.md"
       - Release Notes:
           - "admin/release_notes/index.md"
+          - v2.6: "admin/release_notes/version_2.6.md"
           - v2.5: "admin/release_notes/version_2.5.md"
           - v2.4: "admin/release_notes/version_2.4.md"
           - v2.3: "admin/release_notes/version_2.3.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-golden-config"
-version = "2.6.0a0"
+version = "2.6.0"
 description = "An app for configuration on nautobot"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"
@@ -180,7 +180,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.towncrier]
 package = "nautobot_golden_config"
 directory = "changes"
-filename = "docs/admin/release_notes/version_X.Y.md"
+filename = "docs/admin/release_notes/version_2.6.md"
 template = "development/towncrier_template.j2"
 start_string = "<!-- towncrier release notes start -->"
 issue_format = "[#{issue}](https://github.com/nautobot/nautobot-app-golden-config/issues/{issue})"


### PR DESCRIPTION
# v2.6 Release Notes

This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## Release Overview

- Changed minimum Nautobot version to 2.4.20.
- Dropped support for Python 3.9.

## [v2.6.0 (2025-12-05)](https://github.com/nautobot/nautobot-app-golden-config/releases/tag/v2.6.0)

### Housekeeping

- [#1008](https://github.com/nautobot/nautobot-app-golden-config/issues/1008) - Fixed Unittest failure for ConfigPlan allowed_number_of_tree_queries_per_view_type.
- [#1022](https://github.com/nautobot/nautobot-app-golden-config/issues/1022) - Update any call to `get_extra_context` to call super of the method first.
- Rebaked from the cookie `nautobot-app-v2.7.0`.
- Rebaked from the cookie `nautobot-app-v2.7.1`.
- Rebaked from the cookie `nautobot-app-v2.7.2`.
