### PR TITLE
[NTC-4804] Changed compliance rule match_config to preserve leading spaces

### DIFF
--- a/changes/1073.changed
+++ b/changes/1073.changed
@@ -1,0 +1,1 @@
+Changed Compliance Rule's "Config to Match" form field to preserve leading spaces to properly match some operating systems.

--- a/nautobot_golden_config/forms.py
+++ b/nautobot_golden_config/forms.py
@@ -179,6 +179,14 @@ class ComplianceRuleForm(NautobotModelForm):
     """Filter Form for ComplianceRule instances."""
 
     platform = forms.DynamicModelChoiceField(queryset=Platform.objects.all())
+    match_config = django_forms.CharField(
+        required=False,
+        widget=django_forms.Textarea,
+        label="Config to Match",
+        help_text="The config to match that is matched based on the parent most configuration. E.g.: For CLI `router bgp` or `ntp`. For JSON this is a top level key name. For XML this is a xpath query.",
+        # We need to preserve leading spaces for some operating systems.
+        strip=False,
+    )
 
     class Meta:
         """Boilerplate form Meta data for compliance rule."""

--- a/nautobot_golden_config/tests/test_forms.py
+++ b/nautobot_golden_config/tests/test_forms.py
@@ -1,0 +1,52 @@
+"""Test forms for nautobot_golden_config."""
+
+from django.test import TestCase
+from nautobot.dcim.models import Platform
+
+from nautobot_golden_config.choices import ComplianceRuleConfigTypeChoice
+from nautobot_golden_config.forms import ComplianceRuleForm
+from nautobot_golden_config.models import ComplianceFeature
+
+
+class ComplianceRuleFormTestCase(TestCase):
+    """Test ComplianceRuleForm."""
+
+    form_class = ComplianceRuleForm
+
+    @classmethod
+    def setUpTestData(cls):
+        """Setup test data."""
+        cls.platform = Platform.objects.create(name="Platform 1")
+        cls.feature = ComplianceFeature.objects.create(name="Feature 1", slug="feature-1")
+
+    def test_valid_form_data(self):
+        """Test valid form data."""
+        data = {
+            "feature": self.feature,
+            "platform": self.platform,
+            "config_type": ComplianceRuleConfigTypeChoice.TYPE_CLI,
+            "config_ordered": True,
+            "match_config": "config 1",
+        }
+        form = self.form_class(data=data)
+        self.assertTrue(form.is_valid())
+        saved_obj = form.save()
+        self.assertEqual(saved_obj.feature, self.feature)
+        self.assertEqual(saved_obj.platform, self.platform)
+        self.assertEqual(saved_obj.config_type, ComplianceRuleConfigTypeChoice.TYPE_CLI)
+        self.assertEqual(saved_obj.config_ordered, True)
+        self.assertEqual(saved_obj.match_config, "config 1")
+
+    def test_match_config_leading_space(self):
+        """Test that leading spaces are preserved in match config."""
+        data = {
+            "feature": self.feature,
+            "platform": self.platform,
+            "config_type": ComplianceRuleConfigTypeChoice.TYPE_CLI,
+            "config_ordered": True,
+            "match_config": " config 1",
+        }
+        form = self.form_class(data=data)
+        self.assertTrue(form.is_valid())
+        saved_obj = form.save()
+        self.assertEqual(saved_obj.match_config, " config 1")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Golden Config! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1073

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

This PR changes the ComplianceRuleForm `match_config` field to not strip leading or trailing spaces. This is required for some OS as their config may start with a leading space.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests
