### PR TITLE
Support for user-registered jinja extensions in generating Intended Config

### DIFF
--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -25,6 +25,7 @@ from nautobot_golden_config import models
 from nautobot_golden_config.error_codes import ERROR_CODES
 from nautobot_golden_config.utilities import utils
 from nautobot_golden_config.utilities.constant import JINJA_ENV
+from nautobot_golden_config.utilities.jinja_library import update_env
 
 FRAMEWORK_METHODS = {
     "default": utils.default_framework,
@@ -125,6 +126,9 @@ def get_django_env():
     # Use a custom Jinja2 environment instead of Django's to avoid HTML escaping
     jinja_env = SandboxedEnvironment(**JINJA_ENV)
     jinja_env.filters = engines["jinja"].env.filters
+
+    # attach user-registered filters, globals, and tests to jinja_env
+    update_env(jinja_env)
     return jinja_env
 
 

--- a/nautobot_golden_config/utilities/jinja_library.py
+++ b/nautobot_golden_config/utilities/jinja_library.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2012-2013 Andrey Antukh <niwi@niwi.be>
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+from jinja2 import Environment
+
+
+# Global register dict for third party
+# template functions, filters and extensions.
+_local_env = {
+    "globals": {},
+    "tests": {},
+    "filters": {},
+    "extensions": set(),
+}
+
+
+def update_env(env: Environment):
+    """
+    Given a jinja environment, update it with third party
+    collected environment extensions.
+    """
+
+    env.globals.update(_local_env["globals"])
+    env.tests.update(_local_env["tests"])
+    env.filters.update(_local_env["filters"])
+
+    for extension in _local_env["extensions"]:
+        env.add_extension(extension)
+
+
+def _attach_function(attr, func, name=None):
+    if name is None:
+        name = func.__name__
+
+    global _local_env
+    _local_env[attr][name] = func
+    return func
+
+
+def _register_function(attr, name=None, fn=None):
+    if name is None and fn is None:
+
+        def dec(func):
+            return _attach_function(attr, func)
+
+        return dec
+
+    elif name is not None and fn is None:
+        if callable(name):
+            return _attach_function(attr, name)
+        else:
+
+            def dec(func):
+                return _register_function(attr, name, func)
+
+            return dec
+
+    elif name is not None and fn is not None:
+        return _attach_function(attr, fn, name)
+
+    raise RuntimeError("Invalid parameters")
+
+
+def extension(extension):
+    global _local_env
+    _local_env["extensions"].add(extension)
+    return extension
+
+
+def global_function(*args, **kwargs):
+    return _register_function("globals", *args, **kwargs)
+
+
+def test(*args, **kwargs):
+    return _register_function("tests", *args, **kwargs)
+
+
+def filter(*args, **kwargs):
+    return _register_function("filters", *args, **kwargs)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Golden Config! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1080 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

This PR implements support for users (primarily plugin authors for the moment) to write their own jinja extensions, filters, tests, and global functions, and to register those with the Jinja rendering engine (Environment) used by the GC plugin to render Intended Config

This implementation allows users to register these things using a simple set of decorators based on django-jinja's [library](https://niwi.nz/django-jinja/latest/#_registering_filters_in_a_django_way) module

### Example

```python
# my_nautobot_plugin/__init__.py
import .golden_config # noqa
```
```python
# my_nautobot_plugin/golden_config.py

from nautobot_golden_config.utilities import jinja_library as library
import jinja2
import jinja2.ext

@library.test(name="one")
def is_one(n):
    """
    Usage: {% if m is one %}Foo{% endif %}
    """
    return n == 1

@library.filter
def mylower(name):
    """
    Usage: {{ 'Hello'|mylower() }}
    """
    return name.lower()

@library.filter
@jinja2.pass_context
def replace(context, value, x, y):
    """
    Filter with template context. Usage: {{ 'Hello'|replace('H','M') }}
    """
    return value.replace(x, y)


@library.global_function
def now(data):
    """
    Usage: {{ now() }}
    """
    from datetime import datetime
    return datetime.now()

@library.extension
class IncludeFeatureExtension(jinja2.ext.Extension):
    """
    A Jinja extension that adds a new tag, {% include_feature %}, which
    gets transformed into a specialized include statement

    Ex:
        {% include_feature 'intf/switchport' %}

        Turns into:
        {% set feature_name = 'intf/switchport' %}
        {% include feature('intf/switchport') %}
    """

    tags = {"include_feature"}  # pyright: ignore[reportIncompatibleVariableOverride]

    def parse(self, parser):
        """Parse the include_feature tag, transform it into a set statement and an include statement"""

        lineno = next(parser.stream).lineno
        main_node = parser.parse_expression()
        if parser.stream.skip_if("comma"):
            _node = parser.parse_expression()  # type: ignore
            extra_args = [_node]
            feature_name = _node
        else:
            extra_args = []
            feature_name = main_node
        return [
            jinja.nodes.Assign(jinja.nodes.Name("feature_name", "store"), feature_name, lineno=lineno),
            jinja.nodes.Include(
                jinja.nodes.Call(
                    jinja.nodes.Name("feature", "load"),
                    [main_node, *extra_args],
                    [
                        jinja.nodes.Keyword("vendor", nodes.Name("vendor", "load")),
                        jinja.nodes.Keyword("platform_ext", nodes.Name("platform_ext", "load")),
                    ],
                    None,
                    None,
                ),
                True,
                False,
                lineno=lineno,
            ),
        ]


```
## Architectural considerations

Another approach to solving #1080 would have been to extend `get_jinja_env` so that it copies tests/globals/extensions from nautobot's default jinja env, the way it already does for filters. I considered this approach but eventually decided against it because:

extending the logic to import tests, globals, and extensions from the default django jinja env would make the intended_config's SandboxedEnvironment significantly less sandboxed. It would mean filters/tests/globals/extensions intended for use in intended_config would also be imported into nautobot's global jinja env, potentially breaking things, and it would mean that an extensive number of django-specific and nautobot-specific tests/globals/extensions would get imported into the intended_config jinja env, which would at best be less than useful, and at worst possibly break things

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
