### PR TITLE
fix: Make ConfigReplace objects come back in a predictable order

### DIFF
--- a/changes/1085.fixed
+++ b/changes/1085.fixed
@@ -1,0 +1,1 @@
+Made `ConfigReplace` objects come back in a predictable order in `config_backup`.

--- a/nautobot_golden_config/nornir_plays/config_backup.py
+++ b/nautobot_golden_config/nornir_plays/config_backup.py
@@ -113,7 +113,7 @@ def config_backup(job):
 
     # Build a dictionary, with keys of platform.network_driver, and the regex and replace keys for the netutils func.
     replace_regex_dict = {}
-    for regex in ConfigReplace.objects.all():
+    for regex in ConfigReplace.objects.all().order_by("name"):
         if not replace_regex_dict.get(regex.platform.network_driver):
             replace_regex_dict[regex.platform.network_driver] = []
         replace_regex_dict[regex.platform.network_driver].append({"replace": regex.replace, "regex": regex.regex})


### PR DESCRIPTION
## What's Changed
Made `ConfigReplace` ordering deterministic in `config_backup`.

When building the `replace_regex_dict` used during device backup, `ConfigReplace.objects.all()` was being iterated with no explicit ordering. This meant the sequence in which regex substitutions were applied could vary between runs depending on what the database returned.

`.order_by("name")` ensures substitutions are always applied in a deterministic order. This can be important for patterns that have overlapping match criteria — for example, multi-line SNMP community string replacements (don't ask!) where a multi-line pattern must be attempted before a 1-line fallback, otherwise the fallback matches each line individually and the more specific pattern never gets a chance to run.