### PR TITLE
Release v2.6.3

### DIFF
--- a/changes/1094.fixed
+++ b/changes/1094.fixed
@@ -1,1 +1,0 @@
-Fixed an issue where the `isnull` filter was inadvertently being added to extra fields.

--- a/docs/admin/release_notes/version_2.6.md
+++ b/docs/admin/release_notes/version_2.6.md
@@ -10,6 +10,12 @@ This document describes all new features and changes in the release. The format 
 <!-- towncrier release notes start -->
 
 
+## [v2.6.3 (2026-04-08)](https://github.com/nautobot/nautobot-app-golden-config/releases/tag/v2.6.3)
+
+### Fixed
+
+- [#1094](https://github.com/nautobot/nautobot-app-golden-config/issues/1094) - Fixed an issue where the `isnull` filter was inadvertently being added to extra fields.
+
 ## [v2.6.2 (2026-01-28)](https://github.com/nautobot/nautobot-app-golden-config/releases/tag/v2.6.2)
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-golden-config"
-version = "2.6.2"
+version = "2.6.3"
 description = "An app for configuration on nautobot"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## [v2.6.3 (2026-04-08)](https://github.com/nautobot/nautobot-app-golden-config/releases/tag/v2.6.3)

### Fixed

- [#1094](https://github.com/nautobot/nautobot-app-golden-config/issues/1094) - Fixed an issue where the `isnull` filter was inadvertently being added to extra fields.