### PR TITLE
Fixed a race condition when pushing to remote git repos

### DIFF
--- a/changes/968.fixed
+++ b/changes/968.fixed
@@ -1,0 +1,1 @@
+Fixed concurrent Golden Config jobs failing to push due to non-fast-forward errors by retrying with a fetch and rebase.

--- a/nautobot_golden_config/tests/test_utilities/test_git.py
+++ b/nautobot_golden_config/tests/test_utilities/test_git.py
@@ -5,6 +5,7 @@ from unittest.mock import ANY, Mock, patch
 from urllib.parse import quote
 
 from django.conf import settings
+from git.exc import GitCommandError
 from nautobot.extras.datasources.git import get_repo_from_url_to_path_and_from_branch
 from packaging import version
 
@@ -70,3 +71,119 @@ class GitRepoTest(unittest.TestCase):
         GitRepo(self.mock_obj.filesystem_path, git_info.from_url, base_url=self.mock_obj.remote_url)
         mock_repo.assert_not_called()
         mock_repo.clone_from.assert_called_with(git_info.from_url, **self.clone_from_kwargs)
+
+
+@patch("nautobot.core.utils.git.os.path.isdir", Mock(return_value=True))
+@patch("nautobot.core.utils.git.Repo", autospec=True)
+class GitRepoPushTest(unittest.TestCase):
+    """Test GitRepo.push() concurrent-push handling (issue #968)."""
+
+    PATH = "/fake/path"
+    URL = "https://fake.git/org/repository.git"
+
+    @staticmethod
+    def _non_fast_forward_error():
+        return GitCommandError(
+            "git push",
+            1,
+            stderr=b"! [rejected]        main -> main (non-fast-forward)\nerror: failed to push some refs to 'origin'\n",
+        )
+
+    def test_push_retries_on_non_fast_forward_then_succeeds(self, _mock_repo_cls):
+        """Regression test for #968.
+
+        When the remote rejects the initial push as non-fast-forward, push() must fetch from origin,
+        rebase the local branch onto the remote tip, and retry the push so that two concurrent jobs
+        can both succeed.
+        """
+        git_repo = GitRepo(self.PATH, self.URL, base_url=self.URL)
+        repo = git_repo.repo
+        repo.active_branch.name = "main"
+
+        push_result = Mock()
+        push_result.raise_if_error.side_effect = [self._non_fast_forward_error(), None]
+        repo.remotes.origin.push.return_value = push_result
+
+        with patch.object(GitRepo, "fetch") as mock_fetch:
+            git_repo.push()
+
+        self.assertEqual(repo.remotes.origin.push.call_count, 2)
+        self.assertEqual(push_result.raise_if_error.call_count, 2)
+        mock_fetch.assert_called_once_with()
+        repo.git.rebase.assert_called_once_with("origin/main")
+
+    def test_push_succeeds_first_try_no_fetch_or_rebase(self, _mock_repo_cls):
+        """Happy path: a successful push must not fetch or rebase."""
+        git_repo = GitRepo(self.PATH, self.URL, base_url=self.URL)
+        repo = git_repo.repo
+
+        push_result = Mock()
+        push_result.raise_if_error.return_value = None
+        repo.remotes.origin.push.return_value = push_result
+
+        with patch.object(GitRepo, "fetch") as mock_fetch:
+            git_repo.push()
+
+        repo.remotes.origin.push.assert_called_once_with()
+        push_result.raise_if_error.assert_called_once_with()
+        mock_fetch.assert_not_called()
+        repo.git.rebase.assert_not_called()
+
+    def test_push_rebase_conflict_aborts_and_reraises(self, _mock_repo_cls):
+        """A rebase that itself fails must abort and surface the original error, not loop."""
+        git_repo = GitRepo(self.PATH, self.URL, base_url=self.URL)
+        repo = git_repo.repo
+        repo.active_branch.name = "main"
+
+        push_result = Mock()
+        push_result.raise_if_error.side_effect = self._non_fast_forward_error()
+        repo.remotes.origin.push.return_value = push_result
+
+        rebase_conflict = GitCommandError("git rebase", 1, stderr=b"CONFLICT (content): Merge conflict in foo.cfg")
+        repo.git.rebase.side_effect = [rebase_conflict, None]
+
+        with patch.object(GitRepo, "fetch"), self.assertRaises(GitCommandError):
+            git_repo.push()
+
+        self.assertEqual(repo.remotes.origin.push.call_count, 1)
+        self.assertEqual(repo.git.rebase.call_count, 2)
+        repo.git.rebase.assert_any_call("origin/main")
+        repo.git.rebase.assert_any_call("--abort")
+
+    def test_push_non_retryable_error_fails_fast(self, _mock_repo_cls):
+        """Auth/network errors must propagate immediately without fetch or rebase."""
+        git_repo = GitRepo(self.PATH, self.URL, base_url=self.URL)
+        repo = git_repo.repo
+
+        auth_error = GitCommandError("git push", 128, stderr=b"fatal: Authentication failed for 'origin'")
+        push_result = Mock()
+        push_result.raise_if_error.side_effect = auth_error
+        repo.remotes.origin.push.return_value = push_result
+
+        with patch.object(GitRepo, "fetch") as mock_fetch, self.assertRaises(GitCommandError):
+            git_repo.push()
+
+        self.assertEqual(repo.remotes.origin.push.call_count, 1)
+        mock_fetch.assert_not_called()
+        repo.git.rebase.assert_not_called()
+
+    def test_push_exhausts_retries(self, _mock_repo_cls):
+        """If every attempt is rejected as non-fast-forward, the error propagates after max_retries."""
+        git_repo = GitRepo(self.PATH, self.URL, base_url=self.URL)
+        repo = git_repo.repo
+        repo.active_branch.name = "main"
+
+        push_result = Mock()
+        push_result.raise_if_error.side_effect = [
+            self._non_fast_forward_error(),
+            self._non_fast_forward_error(),
+            self._non_fast_forward_error(),
+        ]
+        repo.remotes.origin.push.return_value = push_result
+
+        with patch.object(GitRepo, "fetch") as mock_fetch, self.assertRaises(GitCommandError):
+            git_repo.push(max_retries=3)
+
+        self.assertEqual(repo.remotes.origin.push.call_count, 3)
+        self.assertEqual(mock_fetch.call_count, 2)
+        self.assertEqual(repo.git.rebase.call_count, 2)

--- a/nautobot_golden_config/utilities/git.py
+++ b/nautobot_golden_config/utilities/git.py
@@ -4,6 +4,7 @@ import logging
 
 from git.exc import GitCommandError
 from nautobot.apps.utils import GitRepo as _GitRepo
+from nautobot.core.utils.git import GIT_ENVIRONMENT
 
 LOGGER = logging.getLogger(__name__)
 
@@ -52,6 +53,17 @@ class GitRepo(_GitRepo):  # pylint: disable=too-many-instance-attributes
         self.repo.index.commit(commit_description)
         LOGGER.debug("Commit completed")
 
+    def _identity_environment(self) -> dict:
+        """Retrieve identity environment variables derived from the HEAD commit."""
+        head = self.repo.head.commit
+        return {
+            **GIT_ENVIRONMENT,
+            "GIT_AUTHOR_NAME": head.author.name,
+            "GIT_AUTHOR_EMAIL": head.author.email,
+            "GIT_COMMITTER_NAME": head.committer.name,
+            "GIT_COMMITTER_EMAIL": head.committer.email,
+        }
+
     def push(self, max_retries: int = 3) -> None:
         """Push latest to the git repo, recovering from concurrent-update rejections.
 
@@ -80,7 +92,8 @@ class GitRepo(_GitRepo):  # pylint: disable=too-many-instance-attributes
                 self.fetch()
                 branch = self.repo.active_branch.name
                 try:
-                    self.repo.git.rebase(f"origin/{branch}")
+                    with self.repo.git.custom_environment(**self._identity_environment()):
+                        self.repo.git.rebase(f"origin/{branch}")
                 except GitCommandError:
                     LOGGER.debug("Rebase onto origin/%s failed; aborting and surfacing error.", branch)
                     self.repo.git.rebase("--abort")

--- a/nautobot_golden_config/utilities/git.py
+++ b/nautobot_golden_config/utilities/git.py
@@ -2,9 +2,26 @@
 
 import logging
 
+from git.exc import GitCommandError
 from nautobot.apps.utils import GitRepo as _GitRepo
 
 LOGGER = logging.getLogger(__name__)
+
+_NON_FAST_FORWARD_MARKERS = (
+    "non-fast-forward",
+    "failed to push some refs",
+    "fetch first",
+    "[rejected]",
+)
+
+
+def _is_non_fast_forward(exc: GitCommandError) -> bool:
+    """Return True when a push failure looks like a non-fast-forward rejection."""
+    stderr = getattr(exc, "stderr", None) or ""
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode("utf-8", errors="replace")
+    stderr = stderr.lower()
+    return any(marker in stderr for marker in _NON_FAST_FORWARD_MARKERS)
 
 
 class GitRepo(_GitRepo):  # pylint: disable=too-many-instance-attributes
@@ -35,7 +52,36 @@ class GitRepo(_GitRepo):  # pylint: disable=too-many-instance-attributes
         self.repo.index.commit(commit_description)
         LOGGER.debug("Commit completed")
 
-    def push(self):
-        """Push latest to the git repo."""
-        LOGGER.debug("Push changes to repo")
-        self.repo.remotes.origin.push().raise_if_error()
+    def push(self, max_retries: int = 3) -> None:
+        """Push latest to the git repo, recovering from concurrent-update rejections.
+
+        When a push is rejected as non-fast-forward (another worker pushed first),
+        fetch from origin, rebase the local branch onto the remote tip, and retry
+        the push up to ``max_retries`` times. Other ``GitCommandError`` failures
+        (auth, network, etc.) are re-raised immediately. If a rebase produces a
+        true conflict, the rebase is aborted and the error is surfaced.
+
+        Args:
+            max_retries (int): Maximum push attempts before giving up.
+        """
+        for attempt in range(1, max_retries + 1):
+            try:
+                LOGGER.debug("Push changes to repo (attempt %d/%d)", attempt, max_retries)
+                self.repo.remotes.origin.push().raise_if_error()
+                return
+            except GitCommandError as exc:
+                if not _is_non_fast_forward(exc) or attempt == max_retries:
+                    raise
+                LOGGER.debug(
+                    "Push attempt %d/%d rejected as non-fast-forward; fetching and rebasing onto remote.",
+                    attempt,
+                    max_retries,
+                )
+                self.fetch()
+                branch = self.repo.active_branch.name
+                try:
+                    self.repo.git.rebase(f"origin/{branch}")
+                except GitCommandError:
+                    LOGGER.debug("Rebase onto origin/%s failed; aborting and surfacing error.", branch)
+                    self.repo.git.rebase("--abort")
+                    raise


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Golden Config! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #968

## What's Changed
There was a race condition that exists as part of a few of the jobs in this repo. We fetch the contents at the beginning of the job and then commit and push at the end. Since there was the chance of another process or job pushing to the same repo between those actions, we would sometimes fail to push.

This PR adds a retry mechanism to the git push. When a push failure is detected, it now checks if we can simply try to rebase and push. If there is a genuine merge conflict we let the failure raise as before.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Unit, Integration Tests

NTC-5609