### PR TITLE
fix: handle static DynamicGroups in job filter and repo sync

### DIFF
--- a/changes/1029.fixed
+++ b/changes/1029.fixed
@@ -1,0 +1,1 @@
+Fixed job failure when a device is assigned to a static DynamicGroup linked to a GoldenConfigSetting.

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -76,7 +76,7 @@ def get_refreshed_repos(job_obj, repo_types, data=None):
     repository_records = set()
     for group in dynamic_groups:
         # Make sure the data(device qs) device exist in the dg first.
-        if data.filter(group.generate_query()).exists():
+        if data.filter(pk__in=group.members.values_list("pk", flat=True)).exists():
             for repo_type in repo_types:
                 repo = getattr(group.golden_config_setting, repo_type, None)
                 if repo:

--- a/nautobot_golden_config/tests/test_jobs.py
+++ b/nautobot_golden_config/tests/test_jobs.py
@@ -2,11 +2,14 @@
 
 from unittest.mock import MagicMock, patch
 
+from django.contrib.contenttypes.models import ContentType
 from nautobot.apps.testing import TransactionTestCase, create_job_result_and_run_job
 from nautobot.dcim.models import Device
-from nautobot.extras.models import JobLogEntry
+from nautobot.extras.choices import DynamicGroupTypeChoices
+from nautobot.extras.models import DynamicGroup, GitRepository, GraphQLQuery, JobLogEntry
 
 from nautobot_golden_config import jobs
+from nautobot_golden_config.models import GoldenConfigSetting
 from nautobot_golden_config.tests.conftest import (
     create_device,
     create_orphan_device,
@@ -620,3 +623,50 @@ class GCReposRunAllMultipleTestCase(TransactionTestCase):
 
         log_entries = JobLogEntry.objects.filter(job_result=job_result, grouping="GC Repo Commit and Push")
         self.assertEqual(log_entries.count(), 0)
+
+
+@patch("nautobot_golden_config.nornir_plays.config_backup.run_backup", MagicMock(return_value="foo"))
+@patch.object(jobs, "ensure_git_repository")
+class GCReposStaticGroupTestCase(TransactionTestCase):
+    """Test that jobs succeed when a device belongs to a static DynamicGroup."""
+
+    databases = ("default", "job_logs")
+
+    def setUp(self) -> None:
+        """Setup test data reproducing issue #1029: static group alongside dynamic filter group."""
+        self.device = create_device(name="static-device")
+        dgs_gc_settings_and_job_repo_objects()
+
+        ct_device = ContentType.objects.get_for_model(Device)
+        static_group = DynamicGroup.objects.create(
+            name="static-dg",
+            content_type=ct_device,
+            group_type=DynamicGroupTypeChoices.TYPE_STATIC,
+        )
+        static_group.add_members([self.device])
+
+        GoldenConfigSetting.objects.create(
+            name="static_group_setting",
+            slug="static_group_setting",
+            weight=2000,
+            backup_path_template="test/backup",
+            intended_path_template="test/intended",
+            jinja_path_template="{{jinja_path}}",
+            backup_test_connectivity=True,
+            dynamic_group=static_group,
+            sot_agg_query=GraphQLQuery.objects.get(name="GC-SoTAgg-Query-1"),
+            backup_repository=GitRepository.objects.get(name="test-backup-repo-1"),
+        )
+        super().setUp()
+
+    @patch("nautobot_golden_config.utilities.constant.ENABLE_BACKUP", True)
+    def test_backup_job_with_static_group_does_not_crash(self, mock_ensure_git_repository):
+        """Backup job must not raise RuntimeError when device is in a static group."""
+        mock_ensure_git_repository.return_value = True
+        job_result = create_job_result_and_run_job(
+            module="nautobot_golden_config.jobs",
+            name="BackupJob",
+            device=Device.objects.filter(name=self.device.name),
+        )
+        log_entries = JobLogEntry.objects.filter(job_result=job_result, grouping="GC After Run")
+        self.assertEqual(log_entries.first().message, "Finished the Backup Configurations job execution.")

--- a/nautobot_golden_config/tests/test_utilities/test_helpers.py
+++ b/nautobot_golden_config/tests/test_utilities/test_helpers.py
@@ -325,7 +325,7 @@ class HelpersTestStaticGroup(TestCase):
     """Test get_job_filter with a static DynamicGroup in scope."""
 
     def setUp(self):
-        """Setup with a dynamic filter group and a static group."""
+        """Set up a static DynamicGroup and a GoldenConfigSetting using it."""
         GitRepository.objects.all().delete()
         create_helper_repo(name="backup-static-test", provides="backupconfigs")
         create_helper_repo(name="intended-static-test", provides="intendedconfigs")
@@ -340,23 +340,7 @@ class HelpersTestStaticGroup(TestCase):
         )
 
         populate_status_choices()
-        self.device = create_device(name="static-filter-device")
-
-        dynamic_group = DynamicGroup.objects.create(
-            name="static-test-dg",
-            content_type=content_type,
-            filter={"platform": ["Platform 1"]},
-        )
-        GoldenConfigSetting.objects.create(
-            name="dynamic_filter_setting",
-            slug="dynamic_filter_setting",
-            weight=1000,
-            backup_repository=GitRepository.objects.get(name="backup-static-test"),
-            intended_repository=GitRepository.objects.get(name="intended-static-test"),
-            jinja_repository=GitRepository.objects.get(name="jinja-static-test"),
-            dynamic_group=dynamic_group,
-            sot_agg_query=graphql_query,
-        )
+        self.device = create_device(name="static-device")
 
         static_group = DynamicGroup.objects.create(
             name="static-type-dg",
@@ -380,9 +364,8 @@ class HelpersTestStaticGroup(TestCase):
         result = get_job_filter()
         self.assertIn(self.device, result)
 
-    def test_device_to_settings_map_static_group_weight_wins(self):
-        """Verify highest weight GoldenConfigSetting wins when device matches both static and filter-based groups."""
+    def test_device_to_settings_map_with_static_group(self):
+        """Verify get_device_to_settings_map resolves a device in a static DynamicGroup to its setting."""
         result = get_device_to_settings_map(queryset=Device.objects.all())
         static_setting = GoldenConfigSetting.objects.get(name="static_group_setting")
-        # static_group_setting (weight=2000) should win over dynamic_filter_setting (weight=1000)
         self.assertEqual(result[self.device.id], static_setting)

--- a/nautobot_golden_config/tests/test_utilities/test_helpers.py
+++ b/nautobot_golden_config/tests/test_utilities/test_helpers.py
@@ -379,3 +379,17 @@ class HelpersTestStaticGroup(TestCase):
         """Verify get_job_filter does not raise when a GoldenConfigSetting uses a static group."""
         result = get_job_filter()
         self.assertIn(self.device, result)
+
+    def test_device_to_settings_map_with_static_group(self):
+        """Verify get_device_to_settings_map correctly maps a device in a static DynamicGroup."""
+        result = get_device_to_settings_map(queryset=Device.objects.all())
+        static_setting = GoldenConfigSetting.objects.get(name="static_group_setting")
+        self.assertIn(self.device.id, result)
+        self.assertEqual(result[self.device.id], static_setting)
+
+    def test_device_to_settings_map_static_group_weight_wins(self):
+        """Verify highest weight GoldenConfigSetting wins when device matches both static and filter-based groups."""
+        result = get_device_to_settings_map(queryset=Device.objects.all())
+        static_setting = GoldenConfigSetting.objects.get(name="static_group_setting")
+        # static_group_setting (weight=2000) should win over dynamic_filter_setting (weight=1000)
+        self.assertEqual(result[self.device.id], static_setting)

--- a/nautobot_golden_config/tests/test_utilities/test_helpers.py
+++ b/nautobot_golden_config/tests/test_utilities/test_helpers.py
@@ -380,13 +380,6 @@ class HelpersTestStaticGroup(TestCase):
         result = get_job_filter()
         self.assertIn(self.device, result)
 
-    def test_device_to_settings_map_with_static_group(self):
-        """Verify get_device_to_settings_map correctly maps a device in a static DynamicGroup."""
-        result = get_device_to_settings_map(queryset=Device.objects.all())
-        static_setting = GoldenConfigSetting.objects.get(name="static_group_setting")
-        self.assertIn(self.device.id, result)
-        self.assertEqual(result[self.device.id], static_setting)
-
     def test_device_to_settings_map_static_group_weight_wins(self):
         """Verify highest weight GoldenConfigSetting wins when device matches both static and filter-based groups."""
         result = get_device_to_settings_map(queryset=Device.objects.all())

--- a/nautobot_golden_config/tests/test_utilities/test_helpers.py
+++ b/nautobot_golden_config/tests/test_utilities/test_helpers.py
@@ -8,6 +8,7 @@ from django.template import engines
 from django.test import TestCase
 from jinja2 import exceptions as jinja_errors
 from nautobot.dcim.models import Device, Location, LocationType, Platform
+from nautobot.extras.choices import DynamicGroupTypeChoices
 from nautobot.extras.management import populate_status_choices
 from nautobot.extras.models import DynamicGroup, GitRepository, GraphQLQuery, Status, Tag
 from nornir_nautobot.exceptions import NornirNautobotException
@@ -318,3 +319,63 @@ class HelpersTest(TestCase):  # pylint: disable=too-many-instance-attributes
         # Regenerate the device to settings map to ensure it is up to date.
         temp_device_to_settings_map = get_device_to_settings_map(queryset=Device.objects.all())
         self.assertEqual(temp_device_to_settings_map[test_device.id], self.test_settings_a)
+
+
+class HelpersTestStaticGroup(TestCase):
+    """Test get_job_filter with a static DynamicGroup in scope."""
+
+    def setUp(self):
+        """Setup with a dynamic filter group and a static group."""
+        GitRepository.objects.all().delete()
+        create_helper_repo(name="backup-static-test", provides="backupconfigs")
+        create_helper_repo(name="intended-static-test", provides="intendedconfigs")
+        create_helper_repo(name="jinja-static-test", provides="jinjatemplate")
+
+        GoldenConfigSetting.objects.all().delete()
+
+        content_type = ContentType.objects.get(app_label="dcim", model="device")
+        graphql_query = GraphQLQuery.objects.create(
+            name="static-group-test-query",
+            query="query ($device_id: ID!) { device(id: $device_id) { name } }",
+        )
+
+        populate_status_choices()
+        self.device = create_device(name="static-filter-device")
+
+        dynamic_group = DynamicGroup.objects.create(
+            name="static-test-dg",
+            content_type=content_type,
+            filter={"platform": ["Platform 1"]},
+        )
+        GoldenConfigSetting.objects.create(
+            name="dynamic_filter_setting",
+            slug="dynamic_filter_setting",
+            weight=1000,
+            backup_repository=GitRepository.objects.get(name="backup-static-test"),
+            intended_repository=GitRepository.objects.get(name="intended-static-test"),
+            jinja_repository=GitRepository.objects.get(name="jinja-static-test"),
+            dynamic_group=dynamic_group,
+            sot_agg_query=graphql_query,
+        )
+
+        static_group = DynamicGroup.objects.create(
+            name="static-type-dg",
+            content_type=content_type,
+            group_type=DynamicGroupTypeChoices.TYPE_STATIC,
+        )
+        static_group.add_members([self.device])
+        GoldenConfigSetting.objects.create(
+            name="static_group_setting",
+            slug="static_group_setting",
+            weight=2000,
+            backup_repository=GitRepository.objects.get(name="backup-static-test"),
+            intended_repository=GitRepository.objects.get(name="intended-static-test"),
+            jinja_repository=GitRepository.objects.get(name="jinja-static-test"),
+            dynamic_group=static_group,
+            sot_agg_query=graphql_query,
+        )
+
+    def test_get_job_filter_with_static_group_does_not_raise(self):
+        """Verify get_job_filter does not raise when a GoldenConfigSetting uses a static group."""
+        result = get_job_filter()
+        self.assertIn(self.device, result)

--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -76,7 +76,15 @@ def get_job_filter(data=None):
         dynamic_group__filter__iexact="{}", dynamic_group__group_type=DynamicGroupTypeChoices.TYPE_DYNAMIC_FILTER
     ).exists():
         for obj in models.GoldenConfigSetting.objects.all():
-            raw_qs = raw_qs | Q(pk__in=obj.dynamic_group.members.values_list("pk", flat=True))
+            if obj.dynamic_group.group_type == DynamicGroupTypeChoices.TYPE_STATIC:
+                raw_qs = raw_qs | Q(
+                    pk__in=obj.dynamic_group.static_group_associations.filter(
+                        associated_object_type__app_label="dcim",
+                        associated_object_type__model="device",
+                    ).values_list("associated_object_id", flat=True)
+                )
+            else:
+                raw_qs = raw_qs | Q(pk__in=obj.dynamic_group.members.values_list("pk", flat=True))
 
     base_qs = Device.objects.filter(raw_qs)
 

--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -48,6 +48,21 @@ FIELDS_PK = {
 FIELDS_NAME = {"tags", "status"}
 
 
+def _dynamic_group_device_pks(dynamic_group):
+    """Return device PKs in a DynamicGroup, dispatching by group_type.
+
+    Static groups raise on ``.members`` because ``.members`` calls
+    ``generate_query()`` which is not implemented for static groups; query
+    ``static_group_associations`` directly instead.
+    """
+    if dynamic_group.group_type == DynamicGroupTypeChoices.TYPE_STATIC:
+        return dynamic_group.static_group_associations.filter(
+            associated_object_type__app_label="dcim",
+            associated_object_type__model="device",
+        ).values_list("associated_object_id", flat=True)
+    return dynamic_group.members.values_list("pk", flat=True)
+
+
 def get_job_filter(data=None):
     """Helper function to return a the filterable list of OS's based on platform.name and a specific custom value."""
     if not data:
@@ -76,15 +91,7 @@ def get_job_filter(data=None):
         dynamic_group__filter__iexact="{}", dynamic_group__group_type=DynamicGroupTypeChoices.TYPE_DYNAMIC_FILTER
     ).exists():
         for obj in models.GoldenConfigSetting.objects.all():
-            if obj.dynamic_group.group_type == DynamicGroupTypeChoices.TYPE_STATIC:
-                raw_qs = raw_qs | Q(
-                    pk__in=obj.dynamic_group.static_group_associations.filter(
-                        associated_object_type__app_label="dcim",
-                        associated_object_type__model="device",
-                    ).values_list("associated_object_id", flat=True)
-                )
-            else:
-                raw_qs = raw_qs | Q(pk__in=obj.dynamic_group.members.values_list("pk", flat=True))
+            raw_qs = raw_qs | Q(pk__in=_dynamic_group_device_pks(obj.dynamic_group))
 
     base_qs = Device.objects.filter(raw_qs)
 

--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -176,20 +176,12 @@ def render_jinja_template(obj, logger, template):
 def get_device_to_settings_map(queryset):
     """Helper function to map heightest weighted GC settings to devices."""
     update_dynamic_groups_cache()
-    annotated_queryset = queryset.all().annotate(
-        gc_settings=Subquery(
-            models.GoldenConfigSetting.objects.filter(
-                dynamic_group__static_group_associations__associated_object_id=OuterRef("id"),
-                dynamic_group__static_group_associations__associated_object_type__app_label="dcim",
-                dynamic_group__static_group_associations__associated_object_type__model="device",
-            )
-            .order_by("-weight")
-            # [:1] is a ORM/DB "limit 1" query, not a python slice.
-            .values("id")[:1]
-        )
-    )
-    gcs = {gc.id: gc for gc in models.GoldenConfigSetting.objects.all()}
-    return {device.id: gcs[device.gc_settings] for device in annotated_queryset}
+    device_to_settings = {}
+    for device in queryset.all():
+        setting = models.GoldenConfigSetting.objects.get_for_device(device)
+        if setting is not None:
+            device_to_settings[device.pk] = setting
+    return device_to_settings
 
 
 def get_json_config(config):

--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 
 from django.conf import settings
 from django.contrib import messages
-from django.db.models import OuterRef, Q, Subquery
+from django.db.models import Q
 from django.template import engines
 from django.urls import reverse
 from django.utils.html import format_html

--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -76,7 +76,7 @@ def get_job_filter(data=None):
         dynamic_group__filter__iexact="{}", dynamic_group__group_type=DynamicGroupTypeChoices.TYPE_DYNAMIC_FILTER
     ).exists():
         for obj in models.GoldenConfigSetting.objects.all():
-            raw_qs = raw_qs | obj.dynamic_group.generate_query()
+            raw_qs = raw_qs | Q(pk__in=obj.dynamic_group.members.values_list("pk", flat=True))
 
     base_qs = Device.objects.filter(raw_qs)
 

--- a/nautobot_golden_config/utilities/helper.py
+++ b/nautobot_golden_config/utilities/helper.py
@@ -48,21 +48,6 @@ FIELDS_PK = {
 FIELDS_NAME = {"tags", "status"}
 
 
-def _dynamic_group_device_pks(dynamic_group):
-    """Return device PKs in a DynamicGroup, dispatching by group_type.
-
-    Static groups raise on ``.members`` because ``.members`` calls
-    ``generate_query()`` which is not implemented for static groups; query
-    ``static_group_associations`` directly instead.
-    """
-    if dynamic_group.group_type == DynamicGroupTypeChoices.TYPE_STATIC:
-        return dynamic_group.static_group_associations.filter(
-            associated_object_type__app_label="dcim",
-            associated_object_type__model="device",
-        ).values_list("associated_object_id", flat=True)
-    return dynamic_group.members.values_list("pk", flat=True)
-
-
 def get_job_filter(data=None):
     """Helper function to return a the filterable list of OS's based on platform.name and a specific custom value."""
     if not data:
@@ -91,7 +76,7 @@ def get_job_filter(data=None):
         dynamic_group__filter__iexact="{}", dynamic_group__group_type=DynamicGroupTypeChoices.TYPE_DYNAMIC_FILTER
     ).exists():
         for obj in models.GoldenConfigSetting.objects.all():
-            raw_qs = raw_qs | Q(pk__in=_dynamic_group_device_pks(obj.dynamic_group))
+            raw_qs = raw_qs | Q(pk__in=obj.dynamic_group.members.values_list("pk", flat=True))
 
     base_qs = Device.objects.filter(raw_qs)
 


### PR DESCRIPTION
Why:
- Nautobot supports two DynamicGroup types: dynamic filter (query-based)
  and static (manually assigned members)
- generate_query() raises RuntimeError on static groups because they
  have no filter expression to evaluate
- This caused ALL Golden Config jobs to crash when any GoldenConfigSetting
  was linked to a static DynamicGroup

What changed:
- jobs.py (get_refreshed_repos): replaced generate_query() with
  group.members.values_list("pk", flat=True) to safely check device
  membership for both group types
- helper.py (get_job_filter): same fix applied where the base device
  queryset is built from all GoldenConfigSettings
- Added regression tests for both code paths

Fixes #1029

<!--
    Thank you for your interest in contributing to Golden Config! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #<ISSUE NUMBER GOES HERE>


**What was changed**

- `jobs.py` (`get_refreshed_repos`): replaced `generate_query()` with
  `group.members.values_list("pk", flat=True)` — works correctly for both
  static and dynamic group types
- `helper.py` (`get_job_filter`): same fix applied where the base device
  queryset is built across all GoldenConfigSettings

## To Do
<img width="1228" height="687" alt="Screenshot 2026-05-06 at 10 21 48 AM" src="https://github.com/user-attachments/assets/891452e7-8c3c-4663-ba9d-24494d8bd3bd" />
<img width="1509" height="673" alt="Screenshot 2026-05-06 at 11 46 45 AM" src="https://github.com/user-attachments/assets/b725cafc-c003-4876-9b85-650e7726297a" />

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design
