### PR TITLE
Fix ConfigPlan "Not Approved" check during Deployment

### DIFF
--- a/changes/1114.fixed
+++ b/changes/1114.fixed
@@ -1,0 +1,1 @@
+Fix the check of whether a Config Plan is Not Approved during deployment

--- a/nautobot_golden_config/nornir_plays/config_deployment.py
+++ b/nautobot_golden_config/nornir_plays/config_deployment.py
@@ -19,7 +19,7 @@ from nornir_nautobot.plugins.tasks.dispatcher import dispatcher
 from nautobot_golden_config.exceptions import ConfigPlanDeploymentFailure
 from nautobot_golden_config.nornir_plays.processor import ProcessGoldenConfig
 from nautobot_golden_config.utilities.config_postprocessing import get_config_postprocessing
-from nautobot_golden_config.utilities.constant import DEFAULT_DEPLOY_STATUS, ENABLE_POSTPROCESSING
+from nautobot_golden_config.utilities.constant import ENABLE_POSTPROCESSING
 from nautobot_golden_config.utilities.db_management import close_threaded_db_connections
 from nautobot_golden_config.utilities.helper import dispatch_params
 from nautobot_golden_config.utilities.logger import NornirLogger
@@ -89,7 +89,7 @@ def config_deployment(job):
 
     logger.debug("Starting config deployment")
     config_plan_qs = job.data["config_plan"]
-    if config_plan_qs.filter(status__name=DEFAULT_DEPLOY_STATUS).exists():
+    if config_plan_qs.filter(status__name="Not Approved").exists():
         error_msg = "`E3025:` Cannot deploy configuration(s). One or more config plans are not approved."
         logger.error(error_msg)
         raise NornirNautobotException(error_msg)

--- a/nautobot_golden_config/tests/test_nornir_plays/test_config_deployment.py
+++ b/nautobot_golden_config/tests/test_nornir_plays/test_config_deployment.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, Mock, patch
 from django.contrib.auth import get_user_model
 from nautobot.dcim.models import Device
 from nautobot.extras.models import JobResult, Status
+from nornir_nautobot.exceptions import NornirNautobotException
 
 from nautobot_golden_config.exceptions import ConfigPlanDeploymentFailure
 from nautobot_golden_config.models import ConfigPlan
@@ -88,5 +89,44 @@ class ConfigDeploymentTest(unittest.TestCase):
             config_deployment(self.job)
 
         # Verify nornir was called
+        mock_nornir.assert_called_once()
+        mock_nr.run.assert_called_once()
+
+    @patch("nautobot_golden_config.nornir_plays.config_deployment.InitNornir")
+    def test_config_deployment_blocks_not_approved_plan(self, mock_nornir):
+        """Guard blocks deployment when any plan is in 'Not Approved' status; other statuses pass through."""
+        extra_plan = ConfigPlan.objects.create(
+            plan_type="manual",
+            device=self.device,
+            config_set="Extra Config Set",
+            status=Status.objects.get(name="Approved"),
+            plan_result=self.plan_result,
+        )
+        # unittest.TestCase has no per-test transaction, so the plan must be removed
+        # after the test to avoid leaking a "Not Approved" plan into other tests.
+        self.addCleanup(extra_plan.delete)
+
+        # Mock nornir for the success phase
+        mock_results = Mock()
+        mock_results.failed = False
+        mock_nr = Mock()
+        mock_nr.with_processors.return_value = mock_nr
+        mock_nr.run.return_value = mock_results
+        mock_nornir.return_value.__enter__.return_value = mock_nr
+
+        # Two Approved plans, deployment proceeds
+        config_deployment(self.job)
+        mock_nornir.assert_called_once()
+        mock_nr.run.assert_called_once()
+
+        # Extra plan Not Approved, guard raises
+        extra_plan.status = Status.objects.get(name="Not Approved")
+        extra_plan.validated_save()
+
+        with self.assertRaises(NornirNautobotException) as ctx:
+            config_deployment(self.job)
+
+        self.assertIn("E3025", str(ctx.exception))
+        # Nornir was not called a second time due to the guard
         mock_nornir.assert_called_once()
         mock_nr.run.assert_called_once()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Golden Config! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #1114

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

The `config_deployment()` nornir play was raising an exception for every ConfigPlan in the job, when the DEFAULT_DEPLOY_STATUS had a value other than `"Not Approved"`. The check for the exception has changed from `status__name=DEFAULT_DEPLOY_STATUS` to `status__name="Not Approved"` in order to take action on the exact condition.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
