### PR TITLE
raise SoftTimeLimitExceeded exeption even when fail_job_on_task_failu…

### DIFF
--- a/changes/1128.fixed
+++ b/changes/1128.fixed
@@ -1,0 +1,1 @@
+Fixed SoftTimeLimitExceeded exception not raised when fail_job_on_task_failure is False

--- a/nautobot_golden_config/jobs.py
+++ b/nautobot_golden_config/jobs.py
@@ -6,6 +6,7 @@
 
 from datetime import datetime
 
+from celery.exceptions import SoftTimeLimitExceeded
 from django.utils.timezone import make_aware
 from nautobot.apps.jobs import (
     BooleanVar,
@@ -184,6 +185,8 @@ def gc_repos(func):
         # This is where the specific jobs run method runs via this decorator.
         try:
             func(self, *args, **kwargs)
+        except SoftTimeLimitExceeded:
+            raise
         except Exception as error:  # pylint: disable=broad-exception-caught
             error_msg = f"`E3001:` General Exception handler, original error message ```{error}```"
             # Raise error only if the job kwarg (checkbox) is selected to do so on the job execution form.


### PR DESCRIPTION

# Closes: #1128 

## What's Changed
- Raise SoftTimeLimitExceeded exception even when `fail_job_on_task_failure` is False


## To Do
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
