### PR TITLE
fix: Dropdown caret in the Add button for config plan list view.

### DIFF
--- a/changes/1134.fixed
+++ b/changes/1134.fixed
@@ -1,0 +1,1 @@
+Fixed the Config Plan list view rendering an empty action-button dropdown caret and squared-off "Add" button corners; the caret is now hidden and the "Add" button renders with rounded corners.

--- a/nautobot_golden_config/templates/nautobot_golden_config/configplan_list.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/configplan_list.html
@@ -2,6 +2,22 @@
 {% load static %}
 
 
+{% block extra_styles %}
+    {{ block.super }}
+    {# ConfigPlan supports neither import nor export, so core's object_list template renders the "Add" #}
+    {# button's dropdown caret with an empty menu. Hide the caret to avoid an empty dropdown. #}
+    <style>
+        #actions-dropdown { display: none; }
+        /* With the caret hidden, the "Add" button is effectively standalone, but Bootstrap still */
+        /* squares its right corners because it is not the last child of the btn-group. Round them. */
+        #add-button {
+            border-top-right-radius: var(--bs-btn-border-radius, var(--bs-border-radius, 0.375rem));
+            border-bottom-right-radius: var(--bs-btn-border-radius, var(--bs-border-radius, 0.375rem));
+        }
+    </style>
+{% endblock extra_styles %}
+
+
 {% block buttons %}
     <a class="btn btn-primary" href="{% url 'plugins:nautobot_golden_config:configplan_list' %}?status=Completed" id="completed-button">
         <span aria-hidden="true" class="mdi mdi-link"></span> Completed Plans


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Golden Config! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #<ISSUE NUMBER GOES HERE>1134

## What's Changed
The dropdown caret on the Add config plan button is hidden since export option is not available for config plan list view.

Before

<img width="828" height="136" alt="image" src="https://github.com/user-attachments/assets/166a77b4-a873-43d1-a5b1-9b51ced91995" />

After

<img width="2494" height="228" alt="image" src="https://github.com/user-attachments/assets/135eecdf-23b9-491d-af8f-b24b35516569" />
 
<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [ ] Explanation of Change(s)
- [ ] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [ ] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [ ] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
