### PR TITLE
Fix bulk edit tags on compliance rules for ltm 2.4

### DIFF
--- a/changes/974.added
+++ b/changes/974.added
@@ -1,0 +1,3 @@
+Added tag support to the bulk edit forms for Compliance Rules. Tags are now applied through the `Add tags` and `Remove tags` fields honored by Nautobot's bulk edit view.
+
+Added a selectable (non-default) tags column to the Compliance Rules list views.

--- a/changes/974.added
+++ b/changes/974.added
@@ -1,3 +1,5 @@
 Added tag support to the bulk edit forms for Compliance Rules. Tags are now applied through the `Add tags` and `Remove tags` fields honored by Nautobot's bulk edit view.
 
 Added a selectable (non-default) tags column to the Compliance Rules list views.
+
+Added a `Tags` field to the Compliance Rules filter form, so the list view can be filtered by tag from the UI.

--- a/nautobot_golden_config/forms.py
+++ b/nautobot_golden_config/forms.py
@@ -207,9 +207,10 @@ class ComplianceRuleFilterForm(NautobotFilterForm):
     )
 
     feature = forms.DynamicModelMultipleChoiceField(queryset=models.ComplianceFeature.objects.all(), required=False)
+    tags = forms.TagFilterField(model)
 
 
-class ComplianceRuleBulkEditForm(NautobotBulkEditForm, TagsBulkEditFormMixin):
+class ComplianceRuleBulkEditForm(TagsBulkEditFormMixin, NautobotBulkEditForm):
     """BulkEdit form for ComplianceRule instances."""
 
     pk = django_forms.ModelMultipleChoiceField(

--- a/nautobot_golden_config/forms.py
+++ b/nautobot_golden_config/forms.py
@@ -6,6 +6,7 @@ import json
 import django.forms as django_forms
 from django.conf import settings
 from nautobot.apps import forms
+from nautobot.apps.forms import TagsBulkEditFormMixin
 from nautobot.dcim.models import Device, DeviceType, Location, Manufacturer, Platform, Rack, RackGroup
 from nautobot.extras.forms import NautobotBulkEditForm, NautobotFilterForm, NautobotModelForm
 from nautobot.extras.models import DynamicGroup, GitRepository, GraphQLQuery, JobResult, Role, Status, Tag
@@ -208,7 +209,7 @@ class ComplianceRuleFilterForm(NautobotFilterForm):
     feature = forms.DynamicModelMultipleChoiceField(queryset=models.ComplianceFeature.objects.all(), required=False)
 
 
-class ComplianceRuleBulkEditForm(NautobotBulkEditForm):
+class ComplianceRuleBulkEditForm(NautobotBulkEditForm, TagsBulkEditFormMixin):
     """BulkEdit form for ComplianceRule instances."""
 
     pk = django_forms.ModelMultipleChoiceField(

--- a/nautobot_golden_config/tables.py
+++ b/nautobot_golden_config/tables.py
@@ -366,6 +366,7 @@ class ComplianceRuleTable(BaseTable):
     config_ordered = BooleanColumn()
     custom_compliance = BooleanColumn()
     config_remediation = BooleanColumn()
+    tags = TagColumn(url_name="plugins:nautobot_golden_config:compliancerule_list")
 
     class Meta(BaseTable.Meta):
         """Table to display Compliance Rules Meta Data."""
@@ -381,6 +382,7 @@ class ComplianceRuleTable(BaseTable):
             "config_type",
             "custom_compliance",
             "config_remediation",
+            "tags",
         )
         default_columns = (
             "pk",


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Golden Config! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #974 

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->


Added TagsBulkEditFormMixin to bulk edit form class for Compliance Rules.

Added the Tags column in the Compliance Rules table not as a default.

Added the Tags to filter form for Compliance Rules.

## To Do

<!--
    Please feel free to update todos to keep track of your own notes for WIP PRs.
-->
- [x] Explanation of Change(s)
- [x] Added change log fragment(s) (for more information see [the documentation](https://docs.nautobot.com/projects/core/en/stable/development/core/#creating-changelog-fragments))
- [x] Attached Screenshots, Payload Example
- [ ] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [ ] Outline Remaining Work, Constraints from Design
