### PR TITLE
Fix diff2html colors being unreadable in dark mode

### DIFF
--- a/changes/1152.fixed
+++ b/changes/1152.fixed
@@ -1,0 +1,1 @@
+Fixed diff2html colors being unreadable in Config Compliance and Config Plan diff views when Nautobot is in dark mode.

--- a/nautobot_golden_config/static/nautobot_golden_config/diff2html-3.4.43/diff2html-dark-overrides.css
+++ b/nautobot_golden_config/static/nautobot_golden_config/diff2html-3.4.43/diff2html-dark-overrides.css
@@ -1,0 +1,36 @@
+/*
+ * Dark-mode overrides for nautobot-golden-config's vendored diff2html 3.4.43 CSS.
+ * diff2html.min.css ships a single hardcoded light palette with no dark variant,
+ * which is unreadable against Nautobot's own dark theme. Scoped under Nautobot's
+ * existing [data-bs-theme="dark"] attribute so light-mode users are unaffected.
+ * Upstream bug: https://github.com/nautobot/nautobot-app-golden-config/issues/1152
+ */
+[data-bs-theme="dark"] .d2h-wrapper,
+[data-bs-theme="dark"] .d2h-file-wrapper,
+[data-bs-theme="dark"] .d2h-file-diff,
+[data-bs-theme="dark"] .d2h-diff-table,
+[data-bs-theme="dark"] .d2h-file-side-diff { background-color:#26282c; }
+[data-bs-theme="dark"] .d2h-file-header { background-color:#35383e; border-bottom:1px solid #46494f; color:#ececec; }
+[data-bs-theme="dark"] .d2h-file-header .d2h-file-name-wrapper { color:#ececec; }
+[data-bs-theme="dark"] .d2h-file-header .d2h-file-name { color:#7fb3e6; }
+[data-bs-theme="dark"] .d2h-file-wrapper { border:1px solid #40444a; }
+[data-bs-theme="dark"] .d2h-cntx,
+[data-bs-theme="dark"] td.d2h-code-side-line:not(.d2h-ins):not(.d2h-del) { background-color:#26282c; color:#d4d4d4; }
+[data-bs-theme="dark"] .d2h-code-linenumber,
+[data-bs-theme="dark"] .d2h-code-side-linenumber { background-color:#202225; border-color:#3a3d42; color:rgba(255,255,255,.35); }
+[data-bs-theme="dark"] .d2h-code-side-emptyplaceholder,
+[data-bs-theme="dark"] .d2h-emptyplaceholder { background-color:#202225; border-color:#3a3d42; }
+[data-bs-theme="dark"] .d2h-info { background-color:#35383e; border-color:#46494f; color:#c7c7c7; }
+[data-bs-theme="dark"] .d2h-del { background-color:#3a2528; border-color:#5c3438; color:#e7c4c6; }
+[data-bs-theme="dark"] .d2h-ins { background-color:#22332a; border-color:#35503f; color:#c3e6cd; }
+[data-bs-theme="dark"] .d2h-file-diff .d2h-del.d2h-change { background-color:#3d3320; }
+[data-bs-theme="dark"] .d2h-file-diff .d2h-ins.d2h-change { background-color:#223324; }
+[data-bs-theme="dark"] .d2h-code-line,
+[data-bs-theme="dark"] .d2h-code-side-line,
+[data-bs-theme="dark"] .d2h-code-line-ctn { color:#d4d4d4; }
+[data-bs-theme="dark"] .d2h-code-line del,
+[data-bs-theme="dark"] .d2h-code-side-line del { background-color:#6e2f34; color:#f2c1c4; }
+[data-bs-theme="dark"] .d2h-code-line ins,
+[data-bs-theme="dark"] .d2h-code-side-line ins { background-color:#2c5c3d; color:#b7ecc4; }
+[data-bs-theme="dark"] .d2h-lines-added { color:#7fd99a; border-color:#35503f; background:transparent; }
+[data-bs-theme="dark"] .d2h-lines-deleted { color:#e7999c; border-color:#5c3438; background:transparent; }

--- a/nautobot_golden_config/templates/nautobot_golden_config/goldenconfig_detailsmodal.html
+++ b/nautobot_golden_config/templates/nautobot_golden_config/goldenconfig_detailsmodal.html
@@ -1,6 +1,7 @@
 {% load static %}
 <!-- Reference https://cdn.jsdelivr.net/npm/diff2html/bundles/ and obtain files and version folder name -->
 <link href="{% static 'nautobot_golden_config/diff2html-3.4.43/diff2html.min.css' %}" rel="stylesheet" type="text/css"/>
+<link href="{% static 'nautobot_golden_config/diff2html-3.4.43/diff2html-dark-overrides.css' %}" rel="stylesheet" type="text/css"/>
 <script src="{% static 'nautobot_golden_config/diff2html-3.4.43/diff2html.min.js' %}" type="text/javascript"></script>
 <style>
     .d2h-tag {


### PR DESCRIPTION
## What's happening
`nautobot_golden_config/static/nautobot_golden_config/diff2html-3.4.43/diff2html.min.css` ships a single hardcoded light-mode palette (white/pastel-pink/pastel-green table cells, near-black low-opacity text) with no dark variant and no media query. Nautobot itself is fully dark-themed via Bootstrap 5's `data-bs-theme="dark"` attribute on `<html>`, but this vendored stylesheet never accounted for that, making the Config Compliance and Config Plan diff views essentially unreadable in dark mode.

Unchanged/context rows happen to look fine only by accident — `.d2h-cntx` isn't styled by `diff2html.min.css` at all, so it falls through to Nautobot's own dark table default. Every cell diff2html *does* style explicitly (deletions, insertions, line-number gutters, the file header bar) overrides that dark default with hardcoded light colors.

**Before** (Nautobot dark mode, unpatched):

![before](https://raw.githubusercontent.com/agreen/nautobot-app-golden-config/assets/dark-mode-screenshots/diff2html-dark-mode-before.png)

**After** (this PR):

![after](https://raw.githubusercontent.com/agreen/nautobot-app-golden-config/assets/dark-mode-screenshots/diff2html-dark-mode-after.png)

## What this PR does
Adds a new, separate stylesheet (`diff2html-dark-overrides.css`) rather than editing the vendored `diff2html.min.css` directly, so future `diff2html` version bumps stay clean. Every rule is scoped under Nautobot's existing `[data-bs-theme="dark"]` attribute selector, so **light-mode users are completely unaffected** — nothing changes for them. The one shared template that loads diff2html's assets (`goldenconfig_detailsmodal.html`, used by both the Config Compliance detail view and Config Plan diff rendering) now also loads the new stylesheet.

## Testing
Verified live against a real Config Compliance diff on Nautobot 3.2.4 / golden-config 3.0.7, and reproduced standalone in the two screenshots above using the actual vendored `diff2html.min.js`/`.css` assets and a real (secret-redacted) config diff.

Fixes #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
